### PR TITLE
docs: clarify dashboard/control plane intent

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,10 @@ Ralph watches for `agent-task` notes in a bwrb vault and dispatches them to Open
 
 ## Operator dashboard (planned)
 
-Ralph’s dashboard/control plane is **operator tooling** (not a user-facing UI): a local, token-authenticated API that publishes structured events, with a TUI as the first client.
+Ralph’s control plane (operator dashboard) is **operator tooling** (not a user-facing UI): a local, token-authenticated API that publishes structured events, with a TUI as the first client.
 
-- Local-only by default (`127.0.0.1` + `Authorization: Bearer <token>`); no built-in TLS.
+- Local-only by default (binds `127.0.0.1`) and requires `Authorization: Bearer <token>` on all endpoints; no built-in TLS.
+- Single-user, local-machine threat model; not hardened for hostile networks.
 - Remote access is via SSH port-forwarding or your own proxy.
 - Canonical spec: `docs/product/dashboard-mvp-control-plane-tui.md`
 - Issue map: https://github.com/3mdistal/ralph/issues/22 (MVP epic) and https://github.com/3mdistal/ralph/issues/23 (docs/scope)

--- a/docs/product/dashboard-mvp-control-plane-tui.md
+++ b/docs/product/dashboard-mvp-control-plane-tui.md
@@ -18,11 +18,12 @@ The key design choice is **API-first**: the daemon publishes structured events; 
 
 ## Operator posture
 
-This dashboard/control plane is **operator tooling**, not a user-facing UI.
+This control plane (operator dashboard) is **operator tooling**, not a user-facing UI.
 
 - Intended user: the maintainer/operator running Ralph (single-user posture).
 - API-first: frontends are interchangeable (TUI first; other UIs later).
 - Local-first: token-authenticated and bound to `127.0.0.1` by default; remote access is via SSH port-forwarding or your own proxy.
+- Threat model: single-user, local-machine; not hardened for hostile networks.
 
 ## Goals
 
@@ -311,6 +312,8 @@ Implementation preference:
 - dedicate a summarizer session or small model
 
 ## Issue map
+
+This list is for navigation and may drift; treat the epics as canonical.
 
 Epics:
 - https://github.com/3mdistal/ralph/issues/22 — Dashboard MVP (Control plane + TUI)


### PR DESCRIPTION
## Summary
- Clarify dashboard/control plane as operator-only tooling (API-first; TUI first).
- Call out local-only + token-auth posture (and non-goals like no built-in TLS).
- Add a navigational issue map linking the dashboard MVP epics/sub-issues.

Closes #29

Part of #22 and #23