### PR TITLE
fix: reliably discover queued agent-task notes

### DIFF
--- a/src/__tests__/session-persistence.test.ts
+++ b/src/__tests__/session-persistence.test.ts
@@ -264,8 +264,16 @@ describe("Queue discovery", () => {
   }
 
   beforeEach(async () => {
+    dataset = [];
+    lastCommand = "";
+
     const queue = await loadQueue();
     queue.__setBwrbRunnerForTests(createMockBwrbRunner());
+  });
+
+  afterEach(async () => {
+    const queue = await loadQueue();
+    queue.__resetBwrbRunnerForTests();
   });
 
   test("discovers queued agent-task notes nested under orchestration/tasks/**", async () => {

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -13,10 +13,16 @@ type BwrbProcess = {
 
 type BwrbRunner = (strings: TemplateStringsArray, ...values: unknown[]) => BwrbProcess;
 
-let bwrb: BwrbRunner = $ as unknown as BwrbRunner;
+const DEFAULT_BWRB_RUNNER: BwrbRunner = $ as unknown as BwrbRunner;
+
+let bwrb: BwrbRunner = DEFAULT_BWRB_RUNNER;
 
 export function __setBwrbRunnerForTests(runner: BwrbRunner): void {
   bwrb = runner;
+}
+
+export function __resetBwrbRunnerForTests(): void {
+  bwrb = DEFAULT_BWRB_RUNNER;
 }
 
 export interface AgentTask {


### PR DESCRIPTION
## Summary
- Query agent-task queue via `bwrb list --path orchestration/tasks/** --where ...` so nested notes are discovered.
- Add unit coverage for nested queued tasks and status queries.

Fixes #95

## Testing
- `bun test`
- `bun run typecheck`
