### PR TITLE
Fix merge gating when requiredChecks is empty

### DIFF
--- a/src/__tests__/required-checks.test.ts
+++ b/src/__tests__/required-checks.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+
+import { __summarizeRequiredChecksForTests } from "../worker";
+
+describe("requiredChecks semantics", () => {
+  test("requiredChecks=[] is treated as no gating (success)", () => {
+    const summary = __summarizeRequiredChecksForTests(
+      [{ name: "ci", state: "FAILURE", rawState: "FAILURE" }] as any,
+      []
+    );
+
+    expect(summary.status).toBe("success");
+    expect(summary.required).toEqual([]);
+    expect(summary.available).toEqual(["ci"]);
+  });
+
+  test("requiredChecks with missing check is pending", () => {
+    const summary = __summarizeRequiredChecksForTests([], ["ci"]);
+
+    expect(summary.status).toBe("pending");
+    expect(summary.required).toEqual([{ name: "ci", state: "UNKNOWN", rawState: "missing" }]);
+    expect(summary.available).toEqual([]);
+  });
+});

--- a/src/__tests__/tool-output-budget.test.ts
+++ b/src/__tests__/tool-output-budget.test.ts
@@ -15,7 +15,9 @@ describe("tool output budget", () => {
 
   test("enforceToolOutputBudgetInStorage truncates tool parts", async () => {
     const sessionId = `ses_test_${Date.now()}_${Math.random().toString(16).slice(2)}`;
-    const storageDir = join(homedir(), ".local/share/opencode/storage");
+    const homeDir = homedir();
+    const xdgDataHome = join(homeDir, ".local", "share");
+    const storageDir = join(xdgDataHome, "opencode", "storage");
 
     const messageId = `msg_${Date.now()}_${Math.random().toString(16).slice(2)}`;
 
@@ -38,7 +40,7 @@ describe("tool output budget", () => {
     await writeFile(partPath, JSON.stringify({ type: "toolResult", output: toolOutput }), "utf8");
 
     try {
-      await enforceToolOutputBudgetInStorage(sessionId);
+      await enforceToolOutputBudgetInStorage(sessionId, { homeDir, xdgDataHome });
 
       const updated = JSON.parse(await readFile(partPath, "utf8"));
       expect(typeof updated.output).toBe("string");

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -195,6 +195,10 @@ function summarizeRequiredChecks(allChecks: PrCheck[], requiredChecks: string[])
     return { name, state: match.state, rawState: match.rawState };
   });
 
+  if (requiredChecks.length === 0) {
+    return { status: "success", required: [], available };
+  }
+
   const hasFailure = required.some((c) => c.state === "FAILURE");
   if (hasFailure) return { status: "failure", required, available };
 
@@ -202,6 +206,13 @@ function summarizeRequiredChecks(allChecks: PrCheck[], requiredChecks: string[])
   if (allSuccess) return { status: "success", required, available };
 
   return { status: "pending", required, available };
+}
+
+export function __summarizeRequiredChecksForTests(
+  allChecks: PrCheck[],
+  requiredChecks: string[]
+): RequiredChecksSummary {
+  return summarizeRequiredChecks(allChecks, requiredChecks);
 }
 
 function formatRequiredChecksForHumans(summary: RequiredChecksSummary): string {


### PR DESCRIPTION
## Summary
- Treats `requiredChecks: []` as an explicit opt-out of merge gating (do not wait for CI).
- Adds coverage for required-checks semantics.
- Makes `tool-output-budget` test hermetic under custom `XDG_DATA_HOME`.

## Why
Some repos/PRs produce no status checks for `bot/integration` PRs. Previously, setting `requiredChecks: []` could still result in an infinite wait because the required-checks summary never transitioned to `success`.

## Verification
- `bun test`
- `bun run typecheck`

Fixes #138