### PR TITLE
Run CI on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches:
+      - main
       - bot/integration
 
 permissions:


### PR DESCRIPTION
## Summary
- run the CI workflow on pushes to `main`
- align branch protection required checks with available contexts

## Testing
- not run (workflow change only)