### PR TITLE
feat: GitHub App auth + repo universe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches:
+      - main
       - bot/integration
 
 permissions:


### PR DESCRIPTION
## Summary
- use GitHub App installation token for repo discovery
- filter repos to allowed owners in app-auth listing
- add config/docs for GitHub App auth usage

Fixes #58