### PR TITLE
chore: ignore orchestration scratch dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,9 @@ dist/
 # Local machine config
 src/ralph.json
 
-# bwrb vault content (kept local via .git/info/exclude)
-# (Ralph + bwrb need to traverse orchestration/)
-
+# Local orchestration scratch
+# (Ralph + bwrb may traverse this directory; ignoring only affects git)
+orchestration/
 
 # bwrb local state
 .bwrb/


### PR DESCRIPTION
## Summary
- Add a repo-level ignore for the local `orchestration/` scratch directory.
- Keeps Ralph/bwrb traversal behavior unchanged (this only affects git tracking).

## Testing
- `bun run status` (verified queued tasks still appear)