### PR TITLE
Sync: main into bot/integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,9 @@ dist/
 # Local machine config
 src/ralph.json
 
-# bwrb vault content (kept local via .git/info/exclude)
-# (Ralph + bwrb need to traverse orchestration/)
-
+# Local orchestration scratch
+# (Ralph + bwrb may traverse this directory; ignoring only affects git)
+orchestration/
 
 # bwrb local state
 .bwrb/


### PR DESCRIPTION
## Summary
Sync `origin/main` back into `bot/integration` after a direct-to-main merge.

This keeps `bot/integration` up to date so rollup PRs (e.g. #190) stay mergeable without needing extra "update branch" churn.