### PR TITLE
Rollup: GitHub-first follow-ups

### DIFF
--- a/docs/product/github-first-orchestration.md
+++ b/docs/product/github-first-orchestration.md
@@ -93,6 +93,11 @@ Direct-to-main (override / Pattern B):
 - Midpoint label updates are best-effort and do not block merges; failures are surfaced via non-blocking notifications
   so operators can resolve GitHub permission/config issues without interrupting the queue.
 
+Default-branch unknown fallback:
+- If Ralph cannot determine the repo default branch (e.g. GitHub API auth failure), it applies the midpoint
+  `ralph:in-bot` label only when the configured bot branch name is clearly a bot branch (currently `bot/integration`
+  or any `bot/*` branch). In all other cases it avoids applying `ralph:in-bot`.
+
 ## Escalation protocol
 
 - Ralph removes `ralph:in-progress` and `ralph:queued`, then adds `ralph:escalated`.

--- a/src/__tests__/midpoint-labels.test.ts
+++ b/src/__tests__/midpoint-labels.test.ts
@@ -46,6 +46,17 @@ describe("midpoint label plan", () => {
     });
   });
 
+  test("does not apply midpoint label when default branch is unknown and botBranch is not bot/*", () => {
+    expect(computePlan({ baseBranch: "main", botBranch: "main", defaultBranch: "" })).toEqual({
+      addInBot: false,
+      removeInProgress: true,
+    });
+    expect(computePlan({ baseBranch: "develop", botBranch: "develop", defaultBranch: "" })).toEqual({
+      addInBot: false,
+      removeInProgress: true,
+    });
+  });
+
   test("clears in-progress when base differs from bot branch", () => {
     expect(
       computePlan({ baseBranch: "feature", botBranch: "bot/integration", defaultBranch: "main" })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1510,6 +1510,12 @@ if (args[0] === "status") {
 
   const config = getConfig();
   const queueState = getQueueBackendState();
+
+  // Status reads from the durable SQLite state DB (GitHub issue snapshots, task op
+  // state, idempotency). The daemon initializes this during startup, but CLI
+  // subcommands need to do it explicitly.
+  initStateDb();
+
   const control = readControlStateSnapshot({ log: (message) => console.warn(message), defaults: config.control });
   const controlProfile = control.opencodeProfile?.trim() || "";
 

--- a/src/midpoint-labels.ts
+++ b/src/midpoint-labels.ts
@@ -18,7 +18,16 @@ export function computeMidpointLabelPlan(input: {
   if (!input.defaultBranch.trim()) {
     const normalizedBase = normalizeGitRef(input.baseBranch);
     const normalizedBot = normalizeGitRef(input.botBranch);
-    return { addInBot: normalizedBase === normalizedBot, removeInProgress: true };
+
+    // If we cannot determine the default branch (e.g. auth failure / API outage),
+    // fall back to a convention-based heuristic:
+    // - If we're merging to an explicit bot branch (e.g. bot/integration), treat it
+    //   as a midpoint and apply ralph:in-bot.
+    // - Otherwise, avoid applying the midpoint label (mislabeling a default-branch
+    //   merge as "in-bot" is worse than missing it).
+    const isBotBranch = normalizedBot === "bot/integration" || normalizedBot.startsWith("bot/");
+    const addInBot = normalizedBase === normalizedBot && isBotBranch;
+    return { addInBot, removeInProgress: true };
   }
   const normalizedBase = normalizeGitRef(input.baseBranch);
   const normalizedBot = normalizeGitRef(input.botBranch);


### PR DESCRIPTION
## Summary
Roll up recent GitHub-first stability fixes from `bot/integration` into `main`.

- Fix `ralph status --json` to initialize the local SQLite state DB.
- Refine midpoint label fallback when default branch can’t be fetched.