### PR TITLE
Add tempo auto profile option

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ Edit the control file (`~/.local/state/ralph/control.json`):
 
 Or send `SIGUSR1` to the daemon for immediate reload after editing.
 
-You can also use automatic selection for new tasks:
+You can also use automatic selection for new tasks (for example between "apple", "google", and "tempo"):
 
 ```json
 { "mode": "running", "opencode_profile": "auto" }
@@ -445,6 +445,13 @@ timeZone = "America/Indiana/Indianapolis"
 dayOfWeek = 4
 hour = 19
 minute = 9
+timeZone = "America/Indiana/Indianapolis"
+
+[throttle.perProfile.tempo.reset.weekly]
+# Wed 7:12pm
+dayOfWeek = 3
+hour = 19
+minute = 12
 timeZone = "America/Indiana/Indianapolis"
 ```
 

--- a/src/__tests__/opencode-auto-profile.test.ts
+++ b/src/__tests__/opencode-auto-profile.test.ts
@@ -66,7 +66,19 @@ const defaultGetThrottleDecisionImpl = async (now: number, opts?: GetThrottleArg
     });
   }
 
-  // Later reset, also healthy remaining.
+  if (name === "tempo") {
+    // Later reset, healthy remaining but lower than apple.
+    return mk({
+      state: "ok",
+      nextResetTs: now + 5 * 24 * 60 * 60 * 1000,
+      weeklyHardCapTokens: 1000,
+      weeklyUsedTokens: 200,
+      rolling5hHardCapTokens: 200,
+      rolling5hUsedTokens: 60,
+    });
+  }
+
+  // Later reset, healthiest remaining.
   return mk({
     state: "ok",
     nextResetTs: now + 5 * 24 * 60 * 60 * 1000,
@@ -107,6 +119,7 @@ describe("auto opencode profile selection", () => {
         profiles: {
           apple: { xdgDataHome: "/tmp", xdgConfigHome: "/tmp", xdgStateHome: "/tmp" },
           google: { xdgDataHome: "/tmp", xdgConfigHome: "/tmp", xdgStateHome: "/tmp" },
+          tempo: { xdgDataHome: "/tmp", xdgConfigHome: "/tmp", xdgStateHome: "/tmp" },
         },
       },
     });


### PR DESCRIPTION
## Summary
- include tempo in auto profile selection test fixtures
- document tempo as an auto-switch profile example

Fixes #0