### PR TITLE
Fix wham usage parsing

### DIFF
--- a/src/openai-remote-usage.ts
+++ b/src/openai-remote-usage.ts
@@ -181,6 +181,26 @@ function parseUsageResponse(raw: unknown): {
     }
   }
 
+  // ChatGPT "wham" rate_limit structure.
+  const rateLimit = data.rate_limit;
+  if (rateLimit && typeof rateLimit === "object" && !Array.isArray(rateLimit)) {
+    const rl = rateLimit as Record<string, unknown>;
+
+    const primary = rl.primary_window;
+    if (primary && typeof primary === "object" && !Array.isArray(primary)) {
+      const w = primary as Record<string, unknown>;
+      if (rollingUsedPercent == null) rollingUsedPercent = toFiniteNumber(w.used_percent);
+      if (rollingResetAt == null) rollingResetAt = w.reset_at;
+    }
+
+    const secondary = rl.secondary_window;
+    if (secondary && typeof secondary === "object" && !Array.isArray(secondary)) {
+      const w = secondary as Record<string, unknown>;
+      if (weeklyUsedPercent == null) weeklyUsedPercent = toFiniteNumber(w.used_percent);
+      if (weeklyResetAt == null) weeklyResetAt = w.reset_at;
+    }
+  }
+
   // Flat fallbacks (best-effort).
   if (rollingUsedPercent == null) rollingUsedPercent = toFiniteNumber(data.primary_used_percent);
   if (weeklyUsedPercent == null) weeklyUsedPercent = toFiniteNumber(data.secondary_used_percent);
@@ -210,6 +230,12 @@ async function fetchUsage(accessToken: string): Promise<RemoteOpenaiUsage> {
 
   const raw = await response.json();
   const parsed = parseUsageResponse(raw);
+
+  // If the API response shape changes, do not silently return 0%.
+  if (parsed.rollingUsedPercent == null && parsed.weeklyUsedPercent == null) {
+    const keys = raw && typeof raw === "object" ? Object.keys(raw as Record<string, unknown>).slice(0, 20) : [];
+    throw new Error(`Usage API parse failed (missing used_percent fields). keys=${JSON.stringify(keys)}`);
+  }
 
   const rollingPct = normalizeUsedPct(parsed.rollingUsedPercent);
   const weeklyPct = normalizeUsedPct(parsed.weeklyUsedPercent);


### PR DESCRIPTION
## Why
`ralph usage` was showing 0% used and no reset times because the `wham/usage` endpoint response now uses the `rate_limit.{primary_window,secondary_window}` shape, which we weren't parsing.

## What Changed
- Parse `rate_limit.primary_window` and `rate_limit.secondary_window` in `src/openai-remote-usage.ts`.
- Fail fast if we can't find any `used_percent` fields (avoid silently reporting 0%).
- Add test coverage for the `rate_limit` response shape.

## Testing
- `bun test`
- `bun run typecheck`
- Manual: `bun run usage`