### PR TITLE
Cache remote OpenAI usage for 2 minutes

### DIFF
--- a/docs/ops/opencode-usage-throttling.md
+++ b/docs/ops/opencode-usage-throttling.md
@@ -133,6 +133,9 @@ Add a throttle config section to Ralph:
 - Add a small summary line in `queue.json` / run logs so it’s obvious why work stopped.
 - Add a CLI view of the current meters: `ralph usage` (table) and `ralph usage --json`.
 
+Notes:
+- When using `throttle.openaiSource = "remoteUsage"`, remote usage is cached in-process for ~2 minutes per OpenCode auth file (deduped across concurrent requests).
+
 6) Add a `calibrate` helper (optional but valuable)
 - A CLI command that takes two timestamped dashboard snapshots (5h/week % + reset times) and computes budgets automatically from OpenCode logs.
 

--- a/src/openai-remote-usage.ts
+++ b/src/openai-remote-usage.ts
@@ -272,7 +272,7 @@ export async function getRemoteOpenaiUsage(opts: {
   const autoRefresh = opts.autoRefresh !== false;
 
   const ttlMs =
-    typeof opts.cacheTtlMs === "number" && Number.isFinite(opts.cacheTtlMs) ? Math.max(0, Math.floor(opts.cacheTtlMs)) : 30_000;
+    typeof opts.cacheTtlMs === "number" && Number.isFinite(opts.cacheTtlMs) ? Math.max(0, Math.floor(opts.cacheTtlMs)) : 120_000;
 
   if (!skipCache) {
     const cached = cache.get(opts.authFilePath);

--- a/src/throttle.ts
+++ b/src/throttle.ts
@@ -96,6 +96,8 @@ const DEFAULT_HARD_PCT = 0.75;
 
 const DEFAULT_MIN_CHECK_INTERVAL_MS = 15_000;
 
+const DEFAULT_REMOTE_USAGE_CACHE_TTL_MS = 120_000;
+
 type ThrottleCacheEntry = { lastCheckedAt: number; lastDecision: ThrottleDecision | null };
 const decisionCache = new Map<string, ThrottleCacheEntry>();
 
@@ -637,7 +639,7 @@ export async function getThrottleDecision(
       remoteUsage = await getRemoteOpenaiUsage({
         authFilePath,
         now,
-        cacheTtlMs: minCheckIntervalMs,
+        cacheTtlMs: Math.max(minCheckIntervalMs, DEFAULT_REMOTE_USAGE_CACHE_TTL_MS),
         autoRefresh: true,
         skipCache: false,
       });


### PR DESCRIPTION
## Why
Remote usage-based throttling is now the default. Caching remote meters for only ~15s can still result in frequent calls (especially with multiple workers / repeated commands).

## What Changed
- Default in-process TTL for `getRemoteOpenaiUsage` is now 120s.
- Throttle integration enforces a minimum remote TTL of 120s (still respects larger `throttle.minCheckIntervalMs`).

## Testing
- `bun test`
- `bun run typecheck`