### PR TITLE
chore: add bwrb legacy guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Ralph loads config from `~/.ralph/config.toml`, then `~/.ralph/config.json`, the
 
 When using the GitHub queue backend, `bwrbVault` is optional. When `queueBackend = "bwrb"`, `bwrbVault` resolves to the nearest directory containing `.bwrb/schema.json` starting from the current working directory (fallback: `process.cwd()`). This is a convenience for local development; for daemon use, set `bwrbVault` explicitly so Ralph always reads/writes the same queue. This repo ships with a vault schema at `.bwrb/schema.json`, so you can use your `ralph` checkout as the vault (and keep orchestration notes out of unrelated repos).
 
+`bwrb` is a legacy backend. GitHub issues plus `~/.ralph/state.sqlite` are the canonical queue surfaces. Existing bwrb usage (escalation notes, agent-run notes, and notifications) is best-effort mirror output only, and new bwrb-dependent behavior should not be added.
+
 Note: `orchestration/` is gitignored in this repo, but bwrb still needs to traverse it for queue operations. `.bwrbignore` re-includes `orchestration/**` for bwrb even when `.gitignore` excludes it; if your queue appears empty, check `bwrb --version` and upgrade to >= 0.1.3.
 
 Config is loaded once at startup, so restart the daemon after editing.

--- a/docs/product/github-first-orchestration.md
+++ b/docs/product/github-first-orchestration.md
@@ -13,6 +13,8 @@ Migration policy for `state.sqlite`: see `docs/ops/state-sqlite.md`.
   and last-sync cursors. These do not round-trip to GitHub.
 - bwrb notes (if present) are optional audit artifacts, not the queue source of truth.
 
+Legacy note: bwrb is a deprecated backend. Treat bwrb as best-effort mirror output (escalation notes, agent-run notes, notifications). Do not add new bwrb-dependent behavior; GitHub + `~/.ralph/state.sqlite` are the canonical queue surfaces.
+
 ## Ralph-managed labels
 
 Ralph only manages namespaced labels under `ralph:*` and never edits unrelated labels.

--- a/src/__tests__/bwrb-usage-guard.test.ts
+++ b/src/__tests__/bwrb-usage-guard.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { readdir, readFile } from "fs/promises";
+import { join, relative } from "path";
+
+const BWRB_COMMAND_REGEX = /`bwrb\s/g;
+const ROOT = process.cwd();
+const SRC_ROOT = join(ROOT, "src");
+
+const ALLOWED_BWRB_COMMAND_COUNTS = new Map<string, number>([
+  ["src/queue.ts", 4],
+  ["src/notify.ts", 2],
+  ["src/escalation-notes.ts", 2],
+  ["src/worker.ts", 1],
+]);
+
+async function listTypeScriptFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await listTypeScriptFiles(fullPath));
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".ts")) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+describe("bwrb usage guardrail", () => {
+  test("bwrb CLI usage stays within the legacy allowlist", async () => {
+    const files = await listTypeScriptFiles(SRC_ROOT);
+    const counts = new Map<string, number>();
+
+    for (const file of files) {
+      const content = await readFile(file, "utf8");
+      const matches = content.match(BWRB_COMMAND_REGEX);
+      if (!matches) continue;
+
+      const rel = relative(ROOT, file);
+      if (rel.includes("src/__tests__/")) continue;
+      counts.set(rel, matches.length);
+    }
+
+    for (const [file, count] of counts.entries()) {
+      const allowedCount = ALLOWED_BWRB_COMMAND_COUNTS.get(file);
+      expect(allowedCount, `Unexpected bwrb CLI usage in ${file}.`).toBeDefined();
+      expect(count, `Unexpected bwrb CLI usage count in ${file}.`).toBe(allowedCount);
+    }
+
+    for (const [file, allowedCount] of ALLOWED_BWRB_COMMAND_COUNTS.entries()) {
+      const actualCount = counts.get(file) ?? 0;
+      expect(actualCount, `bwrb CLI usage count changed in ${file}.`).toBe(allowedCount);
+    }
+  });
+});

--- a/src/__tests__/status-snapshot.test.ts
+++ b/src/__tests__/status-snapshot.test.ts
@@ -6,7 +6,23 @@ describe("buildStatusSnapshot", () => {
   test("normalizes optional blocked/throttled fields", () => {
     const snapshot = buildStatusSnapshot({
       mode: "running",
-      queue: { backend: "bwrb", health: "ok", fallback: false, diagnostics: null },
+      queue: {
+        backend: "bwrb",
+        desiredBackend: "bwrb",
+        explicit: true,
+        health: "ok",
+        fallback: false,
+        diagnostics: null,
+        notices: [
+          {
+            code: "bwrb-legacy",
+            severity: "warning",
+            message: "bwrb queue backend is legacy; GitHub issues and ~/.ralph/state.sqlite are the canonical queue surfaces.",
+            docsPath: "docs/product/github-first-orchestration.md",
+            suggestedAction: "Prefer queueBackend=github and configure GitHub auth; bwrb output is best-effort only.",
+          },
+        ],
+      },
       controlProfile: null,
       activeProfile: null,
       throttle: { state: "ok" },

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -116,9 +116,12 @@ export async function runStatusCommand(opts: { args: string[]; drain: StatusDrai
       mode,
       queue: {
         backend: queueState.backend,
+        desiredBackend: queueState.desiredBackend,
+        explicit: queueState.explicit,
         health: queueState.health,
         fallback: queueState.fallback,
         diagnostics: queueState.diagnostics ?? null,
+        notices: queueState.notices ?? [],
       },
       controlProfile: controlProfile || null,
       activeProfile: resolvedProfile ?? null,
@@ -180,6 +183,7 @@ export async function runStatusCommand(opts: { args: string[]; drain: StatusDrai
 
   console.log(`Mode: ${mode}`);
   const statusTags = [
+    queueState.backend === "bwrb" ? "legacy" : null,
     queueState.health === "degraded" ? "degraded" : null,
     queueState.fallback ? "fallback" : null,
   ].filter(Boolean);
@@ -187,6 +191,11 @@ export async function runStatusCommand(opts: { args: string[]; drain: StatusDrai
   console.log(`Queue backend: ${queueState.backend}${statusSuffix}`);
   if (queueState.diagnostics) {
     console.log(`Queue diagnostics: ${queueState.diagnostics}`);
+  }
+  if (queueState.notices.length > 0) {
+    for (const notice of queueState.notices) {
+      console.log(`Queue notice: ${notice.message}`);
+    }
   }
   if (opts.drain.pauseRequested) {
     console.log(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1091,6 +1091,13 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  if (queueState.backend === "bwrb" && queueState.notices.length > 0) {
+    if (shouldLog("queue-backend:legacy", 60_000)) {
+      const notice = queueState.notices[0];
+      console.warn(`[ralph:queue] ${notice.message} ${notice.suggestedAction}`);
+    }
+  }
+
   if (queueState.backend === "bwrb") {
     if (!ensureBwrbVaultLayout(config.bwrbVault)) process.exit(1);
   }
@@ -1143,6 +1150,11 @@ async function main(): Promise<void> {
   }
   if (queueState.diagnostics) {
     console.log(`        Queue diagnostics: ${queueState.diagnostics}`);
+  }
+  if (queueState.notices.length > 0) {
+    for (const notice of queueState.notices) {
+      console.log(`        Queue notice: ${notice.message}`);
+    }
   }
   console.log(`        Max workers: ${config.maxWorkers}`);
   console.log(`        Batch size: ${config.batchSize} PRs before rollup`);

--- a/src/status-snapshot.ts
+++ b/src/status-snapshot.ts
@@ -1,8 +1,14 @@
+import type { QueueBackendNotice } from "./queue-backend";
+import type { StatusUsageSnapshot } from "./status-usage";
+
 export type StatusQueueSnapshot = {
   backend: string;
+  desiredBackend: string;
+  explicit: boolean;
   health: string;
   fallback: boolean;
   diagnostics: string | null;
+  notices: QueueBackendNotice[];
 };
 
 export type StatusDrainSnapshot = {
@@ -38,8 +44,6 @@ export type StatusBlockedTask = StatusTaskBase & {
   blockedReason: string | null;
   blockedDetailsSnippet: string | null;
 };
-
-import type { StatusUsageSnapshot } from "./status-usage";
 
 export type StatusSnapshot = {
   mode: string;


### PR DESCRIPTION
## Summary
- document bwrb as legacy/output-only and point to GitHub + ~/.ralph/state.sqlite as canonical
- surface bwrb legacy notices in status output and daemon startup logs
- add a guardrail test to prevent new bwrb CLI usage

## Testing
- bun test
- bun run typecheck (fails: missing bun-types/node in this environment)

Fixes #324