### PR TITLE
feat: surface per-run token totals in status

### DIFF
--- a/src/__tests__/status-run-tokens.test.ts
+++ b/src/__tests__/status-run-tokens.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+
+import { computeAggregateTokens } from "../status-run-tokens";
+
+describe("status run token aggregation", () => {
+  test("returns unknown when any session is missing", () => {
+    const result = computeAggregateTokens([{ total: 10 }, { total: null }]);
+    expect(result).toEqual({ tokensTotal: null, tokensComplete: false });
+  });
+
+  test("sums totals when all sessions are present", () => {
+    const result = computeAggregateTokens([{ total: 4 }, { total: 6 }]);
+    expect(result).toEqual({ tokensTotal: 10, tokensComplete: true });
+  });
+
+  test("returns unknown when no sessions exist", () => {
+    const result = computeAggregateTokens([]);
+    expect(result).toEqual({ tokensTotal: null, tokensComplete: false });
+  });
+});

--- a/src/__tests__/status-snapshot.test.ts
+++ b/src/__tests__/status-snapshot.test.ts
@@ -11,7 +11,20 @@ describe("buildStatusSnapshot", () => {
       activeProfile: null,
       throttle: { state: "ok" },
       escalations: { pending: 0 },
-      inProgress: [],
+      inProgress: [
+        {
+          name: "Task IP",
+          repo: "3mdistal/ralph",
+          issue: "3mdistal/ralph#3",
+          priority: "p2-medium",
+          opencodeProfile: null,
+          sessionId: null,
+          nowDoing: null,
+          line: null,
+          tokensTotal: 42,
+          tokensComplete: true,
+        },
+      ],
       starting: [],
       queued: [],
       throttled: [

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -7,6 +7,7 @@ import { getQueueBackendState, getQueuedTasks, getTasksByStatus } from "../queue
 import { priorityRank } from "../queue/priority";
 import { buildStatusSnapshot } from "../status-snapshot";
 import { collectStatusUsageRows, formatStatusUsageSection } from "../status-usage";
+import { readRunTokenTotals, type SessionTokenReadResult } from "../status-run-tokens";
 import { formatNowDoingLine } from "../live-status";
 import { initStateDb } from "../state";
 import { getThrottleDecision } from "../throttle";
@@ -21,6 +22,8 @@ import {
 
 const STATUS_USAGE_TIMEOUT_MS = 10_000;
 const STATUS_USAGE_CONCURRENCY = 2;
+const STATUS_TOKEN_TIMEOUT_MS = 5_000;
+const STATUS_TOKEN_CONCURRENCY = 3;
 
 type StatusDrainState = {
   requestedAt: number | null;
@@ -95,19 +98,31 @@ export async function runStatusCommand(opts: { args: string[]; drain: StatusDrai
   });
 
   if (json) {
+    const tokenReadCache = new Map<string, Promise<SessionTokenReadResult>>();
     const inProgressWithStatus = await Promise.all(
       inProgress.map(async (task) => {
         const sessionId = task["session-id"]?.trim() || null;
         const nowDoing = sessionId ? await getSessionNowDoing(sessionId) : null;
+        const opencodeProfile = getTaskOpencodeProfileName(task);
+        const tokens = await readRunTokenTotals({
+          repo: task.repo,
+          issue: task.issue,
+          opencodeProfile,
+          timeoutMs: STATUS_TOKEN_TIMEOUT_MS,
+          concurrency: STATUS_TOKEN_CONCURRENCY,
+          cache: tokenReadCache,
+        });
         return {
           name: task.name,
           repo: task.repo,
           issue: task.issue,
           priority: task.priority ?? "p2-medium",
-          opencodeProfile: getTaskOpencodeProfileName(task),
+          opencodeProfile,
           sessionId,
           nowDoing,
           line: sessionId && nowDoing ? formatNowDoingLine(nowDoing, formatTaskLabel(task)) : null,
+          tokensTotal: tokens.tokensTotal,
+          tokensComplete: tokens.tokensComplete,
         };
       })
     );
@@ -211,8 +226,19 @@ export async function runStatusCommand(opts: { args: string[]; drain: StatusDrai
   }
 
   console.log(`In-progress tasks: ${inProgress.length}`);
+  const tokenReadCache = new Map<string, Promise<SessionTokenReadResult>>();
   for (const task of inProgress) {
-    console.log(`  - ${await getTaskNowDoingLine(task)}`);
+    const line = await getTaskNowDoingLine(task);
+    const tokens = await readRunTokenTotals({
+      repo: task.repo,
+      issue: task.issue,
+      opencodeProfile: getTaskOpencodeProfileName(task),
+      timeoutMs: STATUS_TOKEN_TIMEOUT_MS,
+      concurrency: STATUS_TOKEN_CONCURRENCY,
+      cache: tokenReadCache,
+    });
+    const tokensLabel = tokens.tokensComplete && typeof tokens.tokensTotal === "number" ? tokens.tokensTotal : "?";
+    console.log(`  - ${line} tokens=${tokensLabel}`);
   }
 
   console.log(`Blocked tasks: ${blockedSorted.length}`);

--- a/src/opencode-messages-root.ts
+++ b/src/opencode-messages-root.ts
@@ -1,0 +1,44 @@
+import { homedir } from "os";
+import { join } from "path";
+
+import { resolveOpencodeProfile } from "./config";
+
+export type OpencodeMessagesRoot = {
+  effectiveProfile: string | null;
+  xdgDataHome: string;
+  messagesRootDir: string;
+};
+
+export function resolveDefaultXdgDataHome(homeDir: string = homedir()): string {
+  const raw = process.env.XDG_DATA_HOME?.trim();
+  return raw ? raw : join(homeDir, ".local", "share");
+}
+
+export function resolveOpencodeMessagesRootDir(opencodeProfile?: string | null): OpencodeMessagesRoot {
+  const requested = (opencodeProfile ?? "").trim();
+  if (requested) {
+    const resolved = resolveOpencodeProfile(requested);
+    if (resolved) {
+      return {
+        effectiveProfile: resolved.name,
+        xdgDataHome: resolved.xdgDataHome,
+        messagesRootDir: join(resolved.xdgDataHome, "opencode", "storage", "message"),
+      };
+    }
+
+    const xdgDataHome = resolveDefaultXdgDataHome();
+    return { effectiveProfile: null, xdgDataHome, messagesRootDir: join(xdgDataHome, "opencode", "storage", "message") };
+  }
+
+  const resolvedDefault = resolveOpencodeProfile(null);
+  if (resolvedDefault) {
+    return {
+      effectiveProfile: resolvedDefault.name,
+      xdgDataHome: resolvedDefault.xdgDataHome,
+      messagesRootDir: join(resolvedDefault.xdgDataHome, "opencode", "storage", "message"),
+    };
+  }
+
+  const xdgDataHome = resolveDefaultXdgDataHome();
+  return { effectiveProfile: null, xdgDataHome, messagesRootDir: join(xdgDataHome, "opencode", "storage", "message") };
+}

--- a/src/status-run-tokens.ts
+++ b/src/status-run-tokens.ts
@@ -1,0 +1,151 @@
+import { getActiveRalphRunId, listRalphRunSessionIds } from "./state";
+import {
+  readOpencodeSessionTokenTotalsWithQuality,
+  type OpencodeSessionTokenReadResult,
+} from "./opencode-session-tokens";
+import { resolveOpencodeMessagesRootDir } from "./opencode-messages-root";
+
+export type RunTokenTotals = {
+  tokensTotal: number | null;
+  tokensComplete: boolean;
+  sessionCount: number;
+};
+
+export type SessionTokenReadResult = {
+  total: number | null;
+  quality: "ok" | "missing" | "unreadable" | "timeout";
+};
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+const DEFAULT_CONCURRENCY = 3;
+
+function parseIssueNumber(issueRef: string): number | null {
+  const match = issueRef.match(/#(\d+)$/);
+  if (!match) return null;
+  const num = Number(match[1]);
+  return Number.isFinite(num) ? num : null;
+}
+
+export function computeAggregateTokens(sessionTotals: Array<{ total: number | null }>): {
+  tokensTotal: number | null;
+  tokensComplete: boolean;
+} {
+  if (sessionTotals.length === 0) return { tokensTotal: null, tokensComplete: false };
+
+  let total = 0;
+  for (const entry of sessionTotals) {
+    if (typeof entry.total !== "number" || !Number.isFinite(entry.total)) {
+      return { tokensTotal: null, tokensComplete: false };
+    }
+    total += entry.total;
+  }
+
+  return { tokensTotal: total, tokensComplete: true };
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return promise;
+
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`Timeout after ${timeoutMs}ms (${label})`)), timeoutMs);
+  });
+
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+async function readSessionTotals(params: {
+  sessionId: string;
+  messagesRootDir: string;
+  timeoutMs: number;
+}): Promise<SessionTokenReadResult> {
+  try {
+    const result = await withTimeout(
+      readOpencodeSessionTokenTotalsWithQuality({ sessionId: params.sessionId, messagesRootDir: params.messagesRootDir }),
+      params.timeoutMs,
+      params.sessionId
+    );
+
+    if (result.quality !== "ok") {
+      return { total: null, quality: result.quality };
+    }
+
+    return { total: result.totals.total, quality: "ok" };
+  } catch {
+    return { total: null, quality: "timeout" };
+  }
+}
+
+async function collectSessionTotals(opts: {
+  sessionIds: string[];
+  messagesRootDir: string;
+  timeoutMs: number;
+  concurrency: number;
+  cache?: Map<string, Promise<SessionTokenReadResult>>;
+}): Promise<SessionTokenReadResult[]> {
+  const concurrency = Math.max(1, Math.floor(opts.concurrency));
+  const results: SessionTokenReadResult[] = [];
+  let idx = 0;
+
+  const cache = opts.cache ?? new Map<string, Promise<SessionTokenReadResult>>();
+
+  const readCached = (sessionId: string): Promise<SessionTokenReadResult> => {
+    const existing = cache.get(sessionId);
+    if (existing) return existing;
+    const promise = readSessionTotals({ sessionId, messagesRootDir: opts.messagesRootDir, timeoutMs: opts.timeoutMs });
+    cache.set(sessionId, promise);
+    return promise;
+  };
+
+  const next = async (): Promise<void> => {
+    const current = idx;
+    idx += 1;
+    if (current >= opts.sessionIds.length) return;
+
+    const sessionId = opts.sessionIds[current]!;
+    results[current] = await readCached(sessionId);
+    await next();
+  };
+
+  const workers = Array.from({ length: Math.min(concurrency, opts.sessionIds.length) }, () => next());
+  await Promise.all(workers);
+  return results;
+}
+
+export async function readRunTokenTotals(params: {
+  repo: string;
+  issue: string;
+  opencodeProfile: string | null;
+  timeoutMs?: number;
+  concurrency?: number;
+  cache?: Map<string, Promise<SessionTokenReadResult>>;
+}): Promise<RunTokenTotals> {
+  try {
+    const issueNumber = parseIssueNumber(params.issue);
+    if (!issueNumber) return { tokensTotal: null, tokensComplete: false, sessionCount: 0 };
+
+    const runId = getActiveRalphRunId({ repo: params.repo, issueNumber });
+    if (!runId) return { tokensTotal: null, tokensComplete: false, sessionCount: 0 };
+
+    const sessionIds = listRalphRunSessionIds(runId);
+    if (sessionIds.length === 0) return { tokensTotal: null, tokensComplete: false, sessionCount: 0 };
+
+    const messagesRootDir = resolveOpencodeMessagesRootDir(params.opencodeProfile).messagesRootDir;
+    const timeoutMs = params.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const concurrency = params.concurrency ?? DEFAULT_CONCURRENCY;
+    const sessionTotals = await collectSessionTotals({
+      sessionIds,
+      messagesRootDir,
+      timeoutMs,
+      concurrency,
+      cache: params.cache,
+    });
+
+    const aggregate = computeAggregateTokens(sessionTotals.map((entry) => ({ total: entry.total })));
+    return { tokensTotal: aggregate.tokensTotal, tokensComplete: aggregate.tokensComplete, sessionCount: sessionTotals.length };
+  } catch {
+    return { tokensTotal: null, tokensComplete: false, sessionCount: 0 };
+  }
+}

--- a/src/status-snapshot.ts
+++ b/src/status-snapshot.ts
@@ -24,6 +24,8 @@ export type StatusInProgressTask = StatusTaskBase & {
   sessionId: string | null;
   nowDoing: unknown | null;
   line: string | null;
+  tokensTotal?: number | null;
+  tokensComplete?: boolean;
 };
 
 export type StatusThrottledTask = StatusTaskBase & {


### PR DESCRIPTION
## Summary
- compute per-run token totals by aggregating run session logs (with missing-data handling)
- display token totals in `bun run status` text output and `--json` snapshots
- add token/run aggregation tests and state helpers

## Testing
- bun test (fails: missing dist test fixtures + required-checks fetch in dist tests)
- bun run typecheck
- bun run build

Fixes #291