### PR TITLE
fix: stop CI-debug escalation spam

### DIFF
--- a/src/github-labels.ts
+++ b/src/github-labels.ts
@@ -16,7 +16,7 @@ export const RALPH_LABEL_IN_BOT = "ralph:in-bot";
 export const RALPH_LABEL_BLOCKED = "ralph:blocked";
 export const RALPH_LABEL_STUCK = "ralph:stuck";
 export const RALPH_LABEL_DONE = "ralph:done";
-const RALPH_LABEL_ESCALATED = "ralph:escalated";
+export const RALPH_LABEL_ESCALATED = "ralph:escalated";
 
 export const RALPH_WORKFLOW_LABELS: readonly LabelSpec[] = [
   { name: RALPH_LABEL_QUEUED, color: "0366D6", description: "In queue; claimable when not blocked or escalated" },

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -52,7 +52,7 @@ import {
 } from "./escalation";
 import { notifyEscalation, notifyError, notifyTaskComplete, type EscalationContext } from "./notify";
 import { drainQueuedNudges } from "./nudge";
-import { RALPH_LABEL_BLOCKED, RALPH_LABEL_STUCK } from "./github-labels";
+import { RALPH_LABEL_BLOCKED, RALPH_LABEL_ESCALATED, RALPH_LABEL_STUCK } from "./github-labels";
 import { executeIssueLabelOps, type LabelOp } from "./github/issue-label-io";
 import { GitHubApiError, GitHubClient, splitRepoFullName } from "./github/client";
 import { createGhRunner } from "./github/gh-runner";
@@ -212,7 +212,7 @@ const IGNORED_BODY_DEPS_LOG_MAX_KEYS = 2000;
 const BLOCKED_REASON_MAX_LEN = 200;
 const BLOCKED_DETAILS_MAX_LEN = 2000;
 const CI_DEBUG_LEASE_TTL_MS = 20 * 60_000;
-const CI_DEBUG_COMMENT_SCAN_LIMIT = 50;
+const CI_DEBUG_COMMENT_SCAN_LIMIT = 100;
 const CI_DEBUG_COMMENT_MIN_EDIT_MS = 60_000;
 const MERGE_CONFLICT_LEASE_TTL_MS = 20 * 60_000;
 const MERGE_CONFLICT_COMMENT_SCAN_LIMIT = 50;
@@ -4144,17 +4144,6 @@ ${guidance}`
     return lines.join("\n");
   }
 
-  private async writeCiDebugEscalationComment(params: {
-    issueNumber: number;
-    body: string;
-  }): Promise<void> {
-    const { owner, name } = splitRepoFullName(this.repo);
-    await this.github.request(`/repos/${owner}/${name}/issues/${params.issueNumber}/comments`, {
-      method: "POST",
-      body: { body: params.body },
-    });
-  }
-
   private async runCiDebugRecovery(params: {
     task: AgentTask;
     issueNumber: string;
@@ -4242,32 +4231,36 @@ ${guidance}`
         attempts,
         reason,
       });
-      await this.writeCiDebugEscalationComment({ issueNumber: Number(params.issueNumber), body: escalationBody });
 
       const wasEscalated = params.task.status === "escalated";
-      const escalated = await this.queue.updateTaskStatus(params.task, "escalated");
-      if (escalated) {
-        applyTaskPatch(params.task, "escalated", {});
-      }
-      await this.writeEscalationWriteback(params.task, { reason, escalationType: "blocked" });
-      await this.notify.notifyEscalation({
-        taskName: params.task.name,
-        taskFileName: params.task._name,
-        taskPath: params.task._path,
-        issue: params.task.issue,
-        repo: this.repo,
-        sessionId: params.task["session-id"]?.trim() || undefined,
-        reason,
-        escalationType: "blocked",
-        planOutput: escalationBody,
-      });
+      if (!wasEscalated) {
+        const escalated = await this.queue.updateTaskStatus(params.task, "escalated");
+        if (escalated) {
+          applyTaskPatch(params.task, "escalated", {});
+        }
 
-      if (escalated && !wasEscalated) {
-        await this.recordEscalatedRunNote(params.task, {
+        // Use the idempotent escalation writeback comment for the human-facing summary.
+        await this.writeEscalationWriteback(params.task, { reason, details: escalationBody, escalationType: "blocked" });
+
+        await this.notify.notifyEscalation({
+          taskName: params.task.name,
+          taskFileName: params.task._name,
+          taskPath: params.task._path,
+          issue: params.task.issue,
+          repo: this.repo,
+          sessionId: params.task["session-id"]?.trim() || undefined,
           reason,
-          sessionId: params.task["session-id"]?.trim(),
-          details: escalationBody,
+          escalationType: "blocked",
+          planOutput: escalationBody,
         });
+
+        if (escalated) {
+          await this.recordEscalatedRunNote(params.task, {
+            reason,
+            sessionId: params.task["session-id"]?.trim(),
+            details: escalationBody,
+          });
+        }
       }
 
       return {
@@ -4478,6 +4471,12 @@ ${guidance}`
     const { task, issueNumber, taskRepoPath, cacheKey, botBranch, issueMeta, startTime, opencodeXdg, opencodeSessionOptions } = params;
 
     if (!this.isGitHubQueueTask(task)) return null;
+
+    // Escalated issues are explicitly waiting on humans; do not attempt autonomous CI remediation.
+    const issueLabels = issueMeta.labels ?? [];
+    if (task.status === "escalated" || issueLabels.some((label) => label.trim().toLowerCase() === RALPH_LABEL_ESCALATED)) {
+      return null;
+    }
 
     let existingPr: ResolvedIssuePr;
     try {


### PR DESCRIPTION
Ralph was posting a new **CI-debug escalation summary** issue comment each time CI remediation decided to stop (repeated failure / attempts exhausted). When a task got re-processed, this produced notification storms.

Changes:
- Remove the non-idempotent CI-debug escalation summary comment; route the summary through the existing idempotent escalation writeback (details field).
- Only emit escalation notifications on the transition to `escalated` (not on every re-processing pass).
- Skip CI remediation entirely when the issue is already labeled `ralph:escalated`.
- Increase CI-debug status comment scan window (50 -> 100) to reduce state-loss in noisy threads.

Test:
- `bun test`
- `bun run typecheck`
- `bun run knip`
