### PR TITLE
Harden CI-debug checkout/push

### DIFF
--- a/src/__tests__/ci-remediation-attempts.test.ts
+++ b/src/__tests__/ci-remediation-attempts.test.ts
@@ -36,6 +36,21 @@ function buildGithubCommentStub(params: { owner: string; repo: string; issueNumb
 }
 
 describe("CI remediation attempts", () => {
+  test("CI-debug prompt uses detached checkout and push-to-head", () => {
+    const worker = new RepoWorker("3mdistal/ralph", "/tmp");
+    const prompt = (worker as any).buildCiDebugPrompt({
+      prUrl: "https://github.com/3mdistal/ralph/pull/1",
+      baseRefName: "bot/integration",
+      headRefName: "feat/test-branch",
+      summary: { status: "failed", required: [], optional: [] },
+      timedOut: false,
+      remediationContext: "",
+    });
+
+    expect(prompt).toContain("gh pr checkout --detach");
+    expect(prompt).toContain("git push origin HEAD:feat/test-branch");
+  });
+
   test("defaults CI remediation attempts to 5", () => {
     const prev = process.env.RALPH_CI_REMEDIATION_MAX_ATTEMPTS;
     delete process.env.RALPH_CI_REMEDIATION_MAX_ATTEMPTS;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3390,7 +3390,12 @@ ${guidance}`
   }): string {
     const base = params.baseRefName || "(unknown)";
     const head = params.headRefName || "(unknown)";
+    const normalizedHead = params.headRefName ? this.normalizeGitRef(params.headRefName) : "";
     const timedOutLine = params.timedOut ? "Timed out waiting for required checks to complete." : "";
+
+    const pushLine = normalizedHead
+      ? `git push origin HEAD:${normalizedHead}`
+      : "# If head ref is unknown, resolve it and push: gh pr view --json headRefName -q .headRefName";
 
     return [
       "CI-debug run for an existing PR with failing required checks.",
@@ -3408,8 +3413,11 @@ ${guidance}`
       "Commands (run in the CI-debug worktree):",
       "```bash",
       "git fetch origin",
-      `gh pr checkout ${params.prUrl}`,
+      `gh pr checkout --detach ${params.prUrl}`,
       "git status",
+      "",
+      "# After making a deterministic fix and committing it:",
+      pushLine,
       "```",
     ]
       .filter(Boolean)


### PR DESCRIPTION
## Summary
- Update CI-debug prompt to use `gh pr checkout --detach` to avoid local branch/worktree collisions.
- Include explicit push-back step (`git push origin HEAD:<headRefName>`) so deterministic fixes actually advance the PR head SHA.
- Add a regression test to ensure the prompt includes detach + push.

## Testing
- `bun test src/__tests__/ci-remediation-attempts.test.ts`

Fixes #408