### PR TITLE
Stop crashing on planner failure

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -7049,7 +7049,25 @@ ${guidance}`
         if (planResult.watchdogTimeout) {
           return await this.handleWatchdogTimeout(task, cacheKey, "plan", planResult, opencodeXdg);
         }
-        throw new Error(`planner failed: ${planResult.output}`);
+
+        const reason = `planner failed: ${planResult.output}`;
+        const details = planResult.output;
+
+        await this.markTaskBlocked(task, "runtime-error", {
+          reason,
+          details,
+          sessionId: planResult.sessionId,
+          runLogPath: planRunLogPath,
+        });
+        await this.notify.notifyError(`Processing ${task.name}`, reason, task.name);
+
+        return {
+          taskName: task.name,
+          repo: this.repo,
+          outcome: "failed",
+          sessionId: planResult.sessionId,
+          escalationReason: reason,
+        };
       }
 
       // Persist OpenCode session ID for crash recovery


### PR DESCRIPTION
## Summary
- Treat planner (`runAgent`) failure as a handled task failure instead of throwing.
- This keeps the worker loop deterministic in CI/test environments and avoids cascading runtime-error handling when the planner cannot run.

## Testing
- `bun test src/__tests__/integration-harness.test.ts`

Fixes #414