### PR TITLE
fix: reconcile mergeable PRs for queued issues

### DIFF
--- a/docs/product/github-first-orchestration.md
+++ b/docs/product/github-first-orchestration.md
@@ -53,6 +53,7 @@ Note: scheduler "priority tasks" are reserved for resume work and are separate f
 - Deployment model: **single daemon per queue**. Running multiple daemons against the same GitHub queue is unsupported.
 - Stale recovery: Ralph only re-queues `ralph:in-progress` issues when the stored `heartbeat-at` exists and is stale beyond `ownershipTtlMs`.
   Missing or invalid heartbeats do not trigger automatic recovery.
+- Orphan PR reconciliation: if an issue is `ralph:queued` but already has an open PR authored by the configured Ralph GitHub App that closes the issue (e.g. `Fixes #123`) and is mergeable into `bot/integration`, Ralph merges it and applies `ralph:in-bot`.
 
 ## Dependency encoding
 

--- a/src/__tests__/github-app-auth-slug.test.ts
+++ b/src/__tests__/github-app-auth-slug.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+
+import { __setGitHubAuthDepsForTests, __testOnlyFetchAuthenticatedAppSlug } from "../github-app-auth";
+
+describe("github-app-auth app slug", () => {
+  const prior = { ...process.env };
+
+  beforeEach(() => {
+    __setGitHubAuthDepsForTests({
+      readFile: async () => "dummy-key",
+      createSign: (() => {
+        return {
+          update: () => void 0,
+          end: () => void 0,
+          sign: () => new Uint8Array([1, 2, 3]),
+        } as any;
+      }) as any,
+      fetch: async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : String(input);
+        expect(url).toBe("https://api.github.com/app");
+        const auth = (init?.headers as any)?.Authorization ?? (init?.headers as any)?.authorization;
+        expect(String(auth ?? "").startsWith("Bearer ")).toBe(true);
+        return new Response(JSON.stringify({ slug: "teenylilralph" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    });
+  });
+
+  afterEach(() => {
+    process.env = prior;
+  });
+
+  test("fetches slug via /app", async () => {
+    const slug = await __testOnlyFetchAuthenticatedAppSlug({ appId: 123, privateKeyPath: "/tmp/key.pem" });
+    expect(slug).toBe("teenylilralph");
+  });
+});

--- a/src/__tests__/worker-pr-body.test.ts
+++ b/src/__tests__/worker-pr-body.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+
+import { __prBodyClosesIssueForTests } from "../worker";
+
+describe("prBodyClosesIssue", () => {
+  test("detects Fixes/Closes/Resolves directives", () => {
+    expect(__prBodyClosesIssueForTests("Fixes #123", "123")).toBe(true);
+    expect(__prBodyClosesIssueForTests("closes #123", "123")).toBe(true);
+    expect(__prBodyClosesIssueForTests("Resolves #123", "123")).toBe(true);
+  });
+
+  test("requires exact issue number boundary", () => {
+    expect(__prBodyClosesIssueForTests("Fixes #1234", "123")).toBe(false);
+    expect(__prBodyClosesIssueForTests("Fixes #123", "1234")).toBe(false);
+  });
+
+  test("works with CRLF and multiline bodies", () => {
+    const body = "## Summary\r\n- thing\r\n\r\nFixes #9\r\n";
+    expect(__prBodyClosesIssueForTests(body, "9")).toBe(true);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -731,6 +731,31 @@ async function startTask(opts: {
       inFlightTasks.add(key);
     }
 
+    const reconcile = await getOrCreateWorker(repo).tryReconcileMergeablePrForQueuedTask(claimedTask);
+    if (reconcile.handled) {
+      if (reconcile.merged) {
+        try {
+          recordPrSnapshot({ repo, issue: claimedTask.issue, prUrl: reconcile.prUrl, state: PR_STATE_MERGED });
+        } catch {
+          // best-effort
+        }
+        await rollupMonitor.recordMerge(repo, reconcile.prUrl);
+        console.log(`[ralph] Reconciled mergeable PR for ${claimedTask.issue}: ${reconcile.prUrl}`);
+      } else {
+        console.warn(`[ralph] Reconcile merge attempt failed for ${claimedTask.issue}: ${reconcile.reason}`);
+      }
+
+      inFlightTasks.delete(key);
+      forgetOwnedTask(claimedTask);
+      releaseGlobal();
+      releaseRepo();
+      if (!isShuttingDown) {
+        scheduleQueuedTasksSoon();
+        void checkIdleRollups();
+      }
+      return true;
+    }
+
     try {
       const reservation = reserveRepoSlotForTask(claimedTask);
       if (!reservation) {


### PR DESCRIPTION
## What this changes
Ralph can now reconcile and merge "orphan" PRs when an issue is back in `ralph:queued` but already has a mergeable PR created by the configured Ralph GitHub App that closes the issue (e.g. `Fixes #123`).

This avoids the failure mode where a daemon restart happens after PR creation but before the merge step, leaving clean PRs sitting open indefinitely.

## Behavior
- Only considers PRs that:
  - target the repo bot branch (typically `bot/integration`)
  - are mergeable (non-draft, not `DIRTY`)
  - are authored by the configured GitHub App (`/app` slug match)
  - include a closing directive for the issue (`Fixes`/`Closes`/`Resolves`)
- If merged, Ralph applies midpoint labels (`ralph:in-bot`) and clears task op-state fields.

## Tests
- `bun test`
- `bun run typecheck`
- `bun run build`