### PR TITLE
fix: make profile config-driven + stabilize control file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,13 +515,13 @@ Example:
 { "version": 1, "mode": "draining" }
 ```
 
-Schema: `{ "version": 1, "mode": "running"|"draining"|"paused", "pause_requested"?: boolean, "pause_at_checkpoint"?: string, "drain_timeout_ms"?: number, "opencode_profile"?: string }` (unknown fields ignored)
+Schema: `{ "version": 1, "mode": "running"|"draining"|"paused", "pause_requested"?: boolean, "pause_at_checkpoint"?: string, "drain_timeout_ms"?: number }` (unknown fields ignored)
 
 - Enable drain: set `mode` to `draining`
 - Disable drain: set `mode` to `running`
 - Pause all scheduling: set `mode` to `paused`
 - Pause at checkpoint: set `pause_requested=true` and optionally `pause_at_checkpoint`
-- Active OpenCode profile: set `opencode_profile` (affects new tasks only; tasks pin their profile on start)
+- Active OpenCode profile: set `[opencode].defaultProfile` in `~/.ralph/config.toml` (affects new tasks only; tasks pin their profile on start)
 - Reload: daemon polls ~1s; send `SIGUSR1` for immediate reload
 - Observability: logs emit `Control mode: draining|running|paused`, and `ralph status` shows `Mode: ...`
 
@@ -601,18 +601,18 @@ xdgCacheHome = "/Users/you/.opencode-profiles/personal/cache"
 
 ### Switching the active profile
 
-Edit the control file (`~/.local/state/ralph/control.json`):
+Edit `~/.ralph/config.toml`:
 
-```json
-{ "mode": "running", "opencode_profile": "personal" }
+```toml
+[opencode]
+defaultProfile = "personal"
 ```
-
-Or send `SIGUSR1` to the daemon for immediate reload after editing.
 
 You can also use automatic selection for new tasks (for example between "apple", "google", and "tempo"):
 
-```json
-{ "mode": "running", "opencode_profile": "auto" }
+```toml
+[opencode]
+defaultProfile = "auto"
 ```
 
 New tasks will start under the active profile. In-flight tasks continue under their pinned profile.
@@ -700,8 +700,8 @@ Shows the latest persisted deterministic gate state and any bounded artifacts fo
 ### Notes
 
 - Paths must be absolute (no `~` expansion).
-- New tasks start under the active `opencode_profile` from the control file (or `defaultProfile` when unset).
-- `defaultProfile` may be set to `"auto"` to auto-select a profile for new work when no control profile is set.
+- New tasks start under `[opencode].defaultProfile`.
+- `defaultProfile` may be set to `"auto"` to auto-select a profile for new work.
 - Tasks persist `opencode-profile` in frontmatter and always resume under the same profile.
 - Throttle is computed per profile—a throttled profile won't affect tasks on other profiles.
 

--- a/src/__tests__/control-file.test.ts
+++ b/src/__tests__/control-file.test.ts
@@ -8,15 +8,19 @@ import { updateControlFile } from "../control-file";
 
 describe("control file", () => {
   let priorXdgStateHome: string | undefined;
+  let priorHome: string | undefined;
   const tempDirs: string[] = [];
 
   beforeEach(() => {
     priorXdgStateHome = process.env.XDG_STATE_HOME;
+    priorHome = process.env.HOME;
   });
 
   afterEach(() => {
     if (priorXdgStateHome !== undefined) process.env.XDG_STATE_HOME = priorXdgStateHome;
     else delete process.env.XDG_STATE_HOME;
+    if (priorHome !== undefined) process.env.HOME = priorHome;
+    else delete process.env.HOME;
     for (const dir of tempDirs) {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -27,6 +31,7 @@ describe("control file", () => {
     const base = mkdtempSync(join(tmpdir(), "ralph-control-"));
     tempDirs.push(base);
     process.env.XDG_STATE_HOME = base;
+    process.env.HOME = base;
 
     updateControlFile({
       patch: {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,7 +30,7 @@ function printGlobalHelp(): void {
       "Notes:",
       "  Control file: set version=1 and mode=running|draining|paused in $XDG_STATE_HOME/ralph/control.json (fallback ~/.local/state/ralph/control.json; last resort /tmp/ralph/<uid>/control.json).",
       "  Pause at next checkpoint: set pause_requested=true in the same control file (clear to resume).",
-      "  OpenCode profile: set opencode_profile=\"<name>\" in the same control file (affects new tasks).",
+      "  OpenCode profile: set [opencode].defaultProfile in ~/.ralph/config.toml (affects new tasks).",
       "  Reload control file immediately with SIGUSR1 (otherwise polled ~1s).",
     ].join("\n")
   );

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -72,8 +72,8 @@ export async function getStatusSnapshot(): Promise<StatusSnapshot> {
     : null;
 
   const control = readControlStateSnapshot({ log: (message) => console.warn(message), defaults: config.control });
-  const controlProfile = control.opencodeProfile?.trim() || "";
-  const requestedProfile = getRequestedOpencodeProfileName(control.opencodeProfile);
+  const controlProfile = "";
+  const requestedProfile = getRequestedOpencodeProfileName(null);
 
   const now = Date.now();
   const selection = await resolveOpencodeProfileForNewWork(now, requestedProfile);
@@ -254,8 +254,8 @@ export async function runStatusCommand(opts: { args: string[]; drain: StatusDrai
     : null;
 
   const control = readControlStateSnapshot({ log: (message) => console.warn(message), defaults: config.control });
-  const controlProfile = control.opencodeProfile?.trim() || "";
-  const requestedProfile = getRequestedOpencodeProfileName(control.opencodeProfile);
+  const controlProfile = "";
+  const requestedProfile = getRequestedOpencodeProfileName(null);
 
   const now = Date.now();
   const selection = await resolveOpencodeProfileForNewWork(now, requestedProfile);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -6336,9 +6336,8 @@ ${guidance}`
       };
     }
 
-    const defaults = getConfig().control;
-    const control = readControlStateSnapshot({ log: (message) => console.warn(message), defaults });
-    const requested = getRequestedOpencodeProfileName(control.opencodeProfile);
+    // Source of truth is config (opencode.defaultProfile). The control file no longer controls profile.
+    const requested = getRequestedOpencodeProfileName(null);
 
     let resolved = null as ReturnType<typeof resolveOpencodeProfile>;
 
@@ -6366,22 +6365,6 @@ ${guidance}`
       resolved = chosen ? resolveOpencodeProfile(chosen) : null;
     } else {
       resolved = requested ? resolveOpencodeProfile(requested) : null;
-    }
-
-    if (requested && requested !== "auto" && !resolved) {
-      console.warn(
-        `[ralph:worker:${this.repo}] Control opencode_profile=${JSON.stringify(requested)} does not match a configured profile; ` +
-          `falling back to defaultProfile=${JSON.stringify(getOpencodeDefaultProfileName() ?? "")}`
-      );
-      const fallbackRequested = getRequestedOpencodeProfileName(null);
-      if (fallbackRequested === "auto") {
-        const chosen = await resolveAutoOpencodeProfileName(Date.now(), {
-          getThrottleDecision: this.throttle.getThrottleDecision,
-        });
-        resolved = chosen ? resolveOpencodeProfile(chosen) : null;
-      } else {
-        resolved = fallbackRequested ? resolveOpencodeProfile(fallbackRequested) : null;
-      }
     }
 
     if (!resolved) {
@@ -6506,9 +6489,7 @@ ${guidance}`
     if (pinned) {
       decision = await this.throttle.getThrottleDecision(Date.now(), { opencodeProfile: pinned });
     } else {
-      const defaults = getConfig().control;
-      const controlProfile = readControlStateSnapshot({ log: (message) => console.warn(message), defaults }).opencodeProfile;
-      const requestedProfile = getRequestedOpencodeProfileName(controlProfile);
+      const requestedProfile = getRequestedOpencodeProfileName(null);
 
       if (requestedProfile === "auto") {
         const chosen = await resolveAutoOpencodeProfileName(Date.now(), {


### PR DESCRIPTION
## What changed
- Treat `~/.ralph/config.toml` (`[opencode].defaultProfile`) as the only source of truth for choosing the OpenCode profile.
- Ignore (and strip on write) `opencode_profile` in the control file so it can't drift back to a pinned value.
- Resolve the effective `control.json` path from the active daemon record when available, so `XDG_STATE_HOME` differences between shells don't silently target the wrong control file.

## Why
Profile switching via `control.json` was brittle when `XDG_STATE_HOME` varied across environments (e.g. per-profile shells). That could make it look like the profile “kept switching back” while the daemon was still reading a different file.

## Testing
- `cd /home/teenylilmonkey/Developer/worktree-control-file-auto`
- `bun test`