### PR TITLE
Fix: add GitHub API backpressure

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,9 @@ Only these env vars are currently supported (unless noted otherwise):
 | Control plane token | `RALPH_DASHBOARD_TOKEN` | (none) |
 | Control plane replay default | `RALPH_DASHBOARD_REPLAY_DEFAULT` | `50` |
 | Control plane replay max | `RALPH_DASHBOARD_REPLAY_MAX` | `250` |
+| GitHub API max in-flight requests | `RALPH_GITHUB_MAX_INFLIGHT` | `16` |
+| GitHub API max in-flight writes | `RALPH_GITHUB_MAX_INFLIGHT_WRITES` | `2` |
+| GitHub issue sync max in-flight repos | `RALPH_GITHUB_ISSUES_SYNC_MAX_INFLIGHT` | `2` |
 
 Run logs are written under `$XDG_STATE_HOME/ralph/run-logs` (fallback: `~/.local/state/ralph/run-logs`).
 

--- a/src/__tests__/github-client-concurrency.test.ts
+++ b/src/__tests__/github-client-concurrency.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { __resetGitHubClientForTests, GitHubClient } from "../github/client";
+
+type Deferred = { promise: Promise<void>; resolve: () => void };
+
+function defer(): Deferred {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe("GitHubClient concurrency backpressure", () => {
+  let priorFetch: typeof fetch | undefined;
+
+  beforeEach(() => {
+    priorFetch = globalThis.fetch;
+    __resetGitHubClientForTests({ maxInflight: 1, maxInflightWrites: 1 });
+  });
+
+  afterEach(() => {
+    __resetGitHubClientForTests();
+    if (priorFetch) globalThis.fetch = priorFetch;
+  });
+
+  test("serializes concurrent requests when maxInflight=1", async () => {
+    const calls: string[] = [];
+    const gate = defer();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).fetch = async (input: RequestInfo | URL) => {
+      calls.push(String(input));
+      if (calls.length === 1) {
+        await gate.promise;
+      }
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: new Headers({ "Content-Type": "application/json" }),
+      });
+    };
+
+    const client = new GitHubClient("3mdistal/ralph", {
+      getToken: async () => "token",
+    });
+
+    const p1 = client.request("/a", { method: "GET" });
+    const p2 = client.request("/b", { method: "GET" });
+
+    // Let the first request start.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(calls.length).toBe(1);
+
+    gate.resolve();
+    await Promise.all([p1, p2]);
+    expect(calls.length).toBe(2);
+  });
+});

--- a/src/semaphore.ts
+++ b/src/semaphore.ts
@@ -1,13 +1,19 @@
 export type ReleaseFn = () => void;
 
 /**
- * Minimal non-blocking semaphore.
+ * Minimal semaphore.
  *
- * Use `tryAcquire()` to take a permit if available.
- * It returns a release function, or `null` if no permits remain.
+ * - `tryAcquire()` is non-blocking and returns a release function or null.
+ * - `acquire()` waits until a permit is available.
  */
 export class Semaphore {
   private inUse = 0;
+  private readonly waiters: Array<{
+    resolve: (release: ReleaseFn) => void;
+    reject: (error: Error) => void;
+    signal?: AbortSignal;
+    onAbort?: () => void;
+  }> = [];
 
   constructor(private readonly capacity: number) {
     if (!Number.isFinite(capacity) || capacity <= 0) {
@@ -19,6 +25,63 @@ export class Semaphore {
     return Math.max(0, this.capacity - this.inUse);
   }
 
+  private releasePermit(): void {
+    this.inUse = Math.max(0, this.inUse - 1);
+
+    while (this.inUse < this.capacity && this.waiters.length > 0) {
+      const next = this.waiters.shift();
+      if (!next) return;
+
+      if (next.signal?.aborted) {
+        next.onAbort?.();
+        continue;
+      }
+
+      if (next.signal && next.onAbort) {
+        next.signal.removeEventListener("abort", next.onAbort);
+      }
+
+      this.inUse++;
+      let released = false;
+      next.resolve(() => {
+        if (released) return;
+        released = true;
+        this.releasePermit();
+      });
+      return;
+    }
+  }
+
+  async acquire(opts?: { signal?: AbortSignal }): Promise<ReleaseFn> {
+    const release = this.tryAcquire();
+    if (release) return release;
+
+    const signal = opts?.signal;
+    if (signal?.aborted) {
+      throw new Error("Semaphore acquire aborted");
+    }
+
+    return await new Promise<ReleaseFn>((resolve, reject) => {
+      const entry = {
+        resolve,
+        reject: (error: Error) => reject(error),
+        signal,
+        onAbort: undefined as (() => void) | undefined,
+      };
+
+      if (signal) {
+        entry.onAbort = () => {
+          const idx = this.waiters.indexOf(entry);
+          if (idx >= 0) this.waiters.splice(idx, 1);
+          reject(new Error("Semaphore acquire aborted"));
+        };
+        signal.addEventListener("abort", entry.onAbort, { once: true });
+      }
+
+      this.waiters.push(entry);
+    });
+  }
+
   tryAcquire(): ReleaseFn | null {
     if (this.inUse >= this.capacity) return null;
     this.inUse++;
@@ -27,7 +90,8 @@ export class Semaphore {
     return () => {
       if (released) return;
       released = true;
-      this.inUse = Math.max(0, this.inUse - 1);
+
+      this.releasePermit();
     };
   }
 }


### PR DESCRIPTION
## Why
Ralph frequently trips GitHub App installation secondary rate limits when many workers perform GitHub operations concurrently (labels, polling, reconciliation). This stalls queue visibility (eg `ralph repos` / GitHub queue reads) and pushes the queue backend into degraded mode.

## What changed
- Add global GitHub API backpressure in `GitHubClient` with separate caps for total requests vs writes.
- Add a minimal async `Semaphore` to support waiting/backpressure.
- Add issue-sync concurrency limiting and improved rate-limit backoff (honor `Retry-After`; fall back to short delay on rate-limit text).
- Document new env vars in README.

## Config knobs
- `RALPH_GITHUB_MAX_INFLIGHT` (default 16)
- `RALPH_GITHUB_MAX_INFLIGHT_WRITES` (default 2)
- `RALPH_GITHUB_ISSUES_SYNC_MAX_INFLIGHT` (default 2)

## Testing
- `bun test src/__tests__/github-client-rate-limit.test.ts`
- `bun test src/__tests__/github-client-concurrency.test.ts`
- `bun test src/__tests__/github-issues-sync.test.ts`