### PR TITLE
fix: reduce GitHub installation rate-limit churn

### DIFF
--- a/src/__tests__/github-queue-blocked-reconcile.test.ts
+++ b/src/__tests__/github-queue-blocked-reconcile.test.ts
@@ -179,4 +179,70 @@ describe("GitHub queue blocked label reconciliation", () => {
     expect(queued.map((t) => t.issue)).toEqual(["3mdistal/ralph#2"]);
     expect(calls).toEqual([{ repo: "3mdistal/ralph", issueNumber: 2, add: [], remove: ["ralph:blocked"] }]);
   });
+
+  test("does not add ralph:blocked when dependency coverage is unknown", async () => {
+    const now = new Date("2026-01-11T00:00:00.000Z");
+    await writeJson(getRalphConfigJsonPath(), {
+      queueBackend: "github",
+      repos: [
+        {
+          name: "3mdistal/ralph",
+          path: "/tmp/ralph",
+          autoQueue: { enabled: true, scope: "labeled-only", maxPerTick: 50, dryRun: false },
+        },
+      ],
+    });
+
+    const cfgMod = await import("../config");
+    cfgMod.__resetConfigForTests();
+
+    const stateMod = await import("../state");
+    stateMod.closeStateDbForTests();
+    stateMod.initStateDb();
+
+    stateMod.recordIssueSnapshot({
+      repo: "3mdistal/ralph",
+      issue: "3mdistal/ralph#3",
+      title: "Unknown deps",
+      state: "OPEN",
+      url: "https://github.com/3mdistal/ralph/issues/3",
+      githubUpdatedAt: now.toISOString(),
+      at: now.toISOString(),
+    });
+    stateMod.recordIssueLabelsSnapshot({
+      repo: "3mdistal/ralph",
+      issue: "3mdistal/ralph#3",
+      labels: ["ralph:queued"],
+      at: now.toISOString(),
+    });
+
+    const calls: Array<{ repo: string; issueNumber: number; add: string[]; remove: string[] }> = [];
+    const queueMod = await import("../github-queue/io");
+    const driver = queueMod.createGitHubQueueDriver({
+      now: () => now,
+      relationshipsProviderFactory: () => ({
+        getSnapshot: async (issue) => ({
+          issue,
+          signals: [],
+          coverage: { githubDepsComplete: false, githubSubIssuesComplete: false, bodyDeps: false },
+        }),
+      }),
+      io: {
+        ensureWorkflowLabels: async () => ({ ok: true, created: [], updated: [] }),
+        listIssueLabels: async () => ["ralph:queued"],
+        reopenIssue: async () => {},
+        addIssueLabel: async () => {},
+        addIssueLabels: async () => {},
+        removeIssueLabel: async () => ({ removed: true }),
+        mutateIssueLabels: async ({ repo, issueNumber, add, remove }) => {
+          calls.push({ repo, issueNumber, add, remove });
+          return true;
+        },
+      },
+    });
+
+    const queued = await driver.getQueuedTasks();
+    expect(queued.map((t) => t.issue)).toEqual(["3mdistal/ralph#3"]);
+    expect(calls).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Why
Ralph can hit GitHub App installation secondary rate limits during queue reconciliation. When that happens, we were:
- backing off for only ~60s (even when GitHub tells us the full 15-minute penalty window)
- treating unknown dependency coverage as blocked in the GitHub queue, which can cause blocked label churn

## What changed
- Parse the `timestamp ... UTC` embedded in GitHub's rate-limit error messages and back off until that time.
- Expand per-request backoff sleep cap to 20 minutes so a single request can cover the full penalty window.
- GitHub queue blocked-label sweep:
  - cap issues processed per repo per sweep via `RALPH_GITHUB_QUEUE_BLOCKED_SWEEP_MAX_ISSUES` (default 25)
  - reuse a single relationships provider per repo per sweep
  - do not add/remove `ralph:blocked` when dependency coverage is `unknown` (only mutate when the decision is certain)
- Claim gate: treat `confidence=unknown` as non-blocking (logs once per minute per issue), but still block on confirmed dependencies.

## Tests
- `bun test`

Refs #346