### PR TITLE
Drain: honor pause_at_checkpoint for checkpoint pausing

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,7 +527,7 @@ Schema: `{ "version": 1, "mode": "running"|"draining"|"paused", "pause_requested
 - Enable drain: set `mode` to `draining`
 - Disable drain: set `mode` to `running`
 - Pause all scheduling: set `mode` to `paused`
-- Pause at checkpoint: set `pause_requested=true` and optionally `pause_at_checkpoint`
+- Pause at checkpoint: set `pause_requested=true` (pauses at the next checkpoint). If you set `pause_at_checkpoint`, Ralph will keep running until it reaches that named checkpoint, then pause.
 - Active OpenCode profile: set `[opencode].defaultProfile` in `~/.ralph/config.toml` (affects new tasks only; tasks pin their profile on start)
 - Reload: daemon polls ~1s; send `SIGUSR1` for immediate reload
 - Observability: logs emit `Control mode: draining|running|paused`, and `ralph status` shows `Mode: ...`

--- a/src/__tests__/checkpoints-runtime.test.ts
+++ b/src/__tests__/checkpoints-runtime.test.ts
@@ -11,6 +11,7 @@ describe("checkpoint runtime", () => {
 
     await applyCheckpointReached({
       checkpoint: "planned",
+      pauseAtCheckpoint: null,
       state: buildCheckpointState(),
       context: {
         workerId: "worker-1",
@@ -45,5 +46,44 @@ describe("checkpoint runtime", () => {
     expect(persisted.length).toBe(2);
     expect(persisted[0]?.pausedAtCheckpoint).toBe("planned");
     expect(persisted[1]?.pausedAtCheckpoint).toBeNull();
+  });
+
+  test("does not wait when pauseAtCheckpoint does not match", async () => {
+    let pauseRequested = true;
+    const persisted: CheckpointState[] = [];
+    const emitted: string[] = [];
+
+    await applyCheckpointReached({
+      checkpoint: "planned",
+      pauseAtCheckpoint: "pr_ready",
+      state: buildCheckpointState(),
+      context: {
+        workerId: "worker-1",
+      },
+      store: {
+        persist: async (state) => {
+          persisted.push(state);
+        },
+      },
+      pauseSource: {
+        isPauseRequested: () => pauseRequested,
+        waitUntilCleared: async () => {
+          throw new Error("waitUntilCleared should not be called");
+        },
+      },
+      emitter: {
+        emit: (event, _key) => {
+          emitted.push(event.type);
+        },
+      },
+    });
+
+    expect(emitted).toEqual(["worker.checkpoint.reached", "worker.pause.requested"]);
+    expect(persisted.length).toBe(1);
+    expect(persisted[0]?.pausedAtCheckpoint).toBeNull();
+    expect(persisted[0]?.pauseRequested).toBeTrue();
+
+    // Ensure the pause flag wasn't mutated by runtime.
+    expect(pauseRequested).toBeTrue();
   });
 });

--- a/src/checkpoints/core.ts
+++ b/src/checkpoints/core.ts
@@ -52,6 +52,7 @@ export function onCheckpointReached(params: {
   checkpoint: RalphCheckpoint;
   state: CheckpointState;
   pauseRequested: boolean;
+  pauseAtCheckpoint?: RalphCheckpoint | null;
   workerId: string;
 }): { state: CheckpointState; effects: CheckpointEffect[] } {
   if (params.pauseRequested && params.state.pausedAtCheckpoint === params.checkpoint) {
@@ -64,11 +65,14 @@ export function onCheckpointReached(params: {
     };
   }
 
+  const shouldPause =
+    params.pauseRequested && (!params.pauseAtCheckpoint || params.pauseAtCheckpoint === params.checkpoint);
+
   const nextSeq = params.state.checkpointSeq + 1;
   const nextState: CheckpointState = {
     lastCheckpoint: params.checkpoint,
     checkpointSeq: nextSeq,
-    pausedAtCheckpoint: params.pauseRequested ? params.checkpoint : null,
+    pausedAtCheckpoint: shouldPause ? params.checkpoint : null,
     pauseRequested: params.pauseRequested,
   };
 
@@ -100,7 +104,7 @@ export function onCheckpointReached(params: {
     });
   }
 
-  if (params.pauseRequested) {
+  if (shouldPause) {
     effects.push({
       kind: "emit",
       eventType: "worker.pause.reached",

--- a/src/checkpoints/runtime.ts
+++ b/src/checkpoints/runtime.ts
@@ -31,6 +31,7 @@ export type CheckpointEventEmitter = {
 
 export async function applyCheckpointReached(params: {
   checkpoint: RalphCheckpoint;
+  pauseAtCheckpoint?: RalphCheckpoint | null;
   state: CheckpointState;
   context: CheckpointContext;
   store: CheckpointStore;
@@ -43,6 +44,7 @@ export async function applyCheckpointReached(params: {
     checkpoint: params.checkpoint,
     state: params.state,
     pauseRequested,
+    pauseAtCheckpoint: params.pauseAtCheckpoint,
     workerId: params.context.workerId,
   });
 


### PR DESCRIPTION
## Why
When drain/pause is configured with `pause_requested=true` plus a specific `pause_at_checkpoint`, workers should keep running until they reach that checkpoint, then pause. Prior behavior paused at the *next* checkpoint regardless of `pause_at_checkpoint`, making drain checkpoint targeting ineffective.

## What changed
- Checkpoint state machine now pauses only when `pause_at_checkpoint` is unset or matches the reached checkpoint.
- Worker passes validated `pause_at_checkpoint` into checkpoint runtime.
- Added unit tests covering the mismatch case.
- Clarified README semantics for `pause_at_checkpoint`.

## Testing
- Worktree: `cd ../worktree-issue-48-drain-checkpoint`
- Tests: `bun test src/__tests__/checkpoints-core.test.ts src/__tests__/checkpoints-runtime.test.ts`

Fixes #48