### PR TITLE
fix: harden GitHub issue context reads

### DIFF
--- a/src/__tests__/planner-prompt.test.ts
+++ b/src/__tests__/planner-prompt.test.ts
@@ -7,7 +7,8 @@ describe("planner prompt", () => {
     const prompt = buildPlannerPrompt({ repo: "3mdistal/ralph", issueNumber: 65 });
 
     expect(prompt).toContain("Planner prompt v1");
-    expect(prompt).toContain("GH_PAGER=cat gh issue view 65 --repo 3mdistal/ralph --comments");
+    expect(prompt).toContain("gh api repos/3mdistal/ralph/issues/65");
+    expect(prompt).toContain("gh api repos/3mdistal/ralph/issues/65/comments --paginate");
     expect(prompt).toContain("consult @product");
     expect(prompt).toContain("consult @devex");
     expect(prompt).toContain("\"decision\": \"proceed\" | \"escalate\"");

--- a/src/github-app-auth.ts
+++ b/src/github-app-auth.ts
@@ -254,6 +254,17 @@ export async function getInstallationToken(profile: RalphProfile = getProfile())
   return fresh.token;
 }
 
+export function invalidateInstallationTokenCache(profile: RalphProfile = getProfile()): boolean {
+  const cfg = getConfig();
+  const app = getGitHubAppConfigForProfile(profile, cfg);
+  if (!app) return false;
+
+  const cacheKey = buildTokenCacheKey(profile, app);
+  const had = tokenCache.delete(cacheKey);
+  inFlightToken.delete(cacheKey);
+  return had;
+}
+
 export async function resolveGhTokenEnv(): Promise<string | null> {
   const profile = getProfile();
   const cfg = getConfig();

--- a/src/parent-verification-prompt.ts
+++ b/src/parent-verification-prompt.ts
@@ -1,11 +1,13 @@
 type ParentVerificationPromptOptions = {
   repo: string;
   issueNumber: string | number;
+  issueContext?: string | null;
 };
 
 export function buildParentVerificationPrompt(options: ParentVerificationPromptOptions): string {
   const issueNumber = String(options.issueNumber).trim();
   const repo = options.repo.trim();
+  const issueContext = String(options.issueContext ?? "").trim();
 
   return [
     "Parent verification prompt v1",
@@ -15,8 +17,16 @@ export function buildParentVerificationPrompt(options: ParentVerificationPromptO
     "IMPORTANT: This runs in a non-interactive daemon. Do NOT ask questions. If you would normally ask a question, make a reasonable default choice and proceed, stating any assumptions briefly.",
     "",
     "Steps:",
-    "1) Read the GitHub issue body.",
-    `2) Read the issue comments (use 'GH_PAGER=cat gh issue view ${issueNumber} --repo ${repo} --comments' to fetch the full thread; prioritize latest maintainer/owner comments).`,
+    "1) Review the GitHub issue context below (prefetched by the orchestrator when possible).",
+    issueContext ? "---" : null,
+    issueContext ? issueContext : null,
+    issueContext ? "---" : null,
+    "",
+    "If issue context is missing/unavailable, fetch it via REST (avoid `gh issue view`, which uses GraphQL):",
+    "```bash",
+    `gh api repos/${repo}/issues/${issueNumber}`,
+    `gh api repos/${repo}/issues/${issueNumber}/comments --paginate`,
+    "```",
     "3) Decide if any implementation work remains given the issue description, current dependency state, and latest comments.",
     "",
     "Decision guidance:",

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3033,15 +3033,19 @@ ${guidance}`
 
     const [, repo, number] = match;
     try {
-      const result = await ghRead(repo)`gh issue view ${number} --repo ${repo} --json state,stateReason,closedAt,url,labels,title`.quiet();
-      const data = JSON.parse(result.stdout.toString());
+      const prefetchTimeoutMs = Number.isFinite(Number(process.env.RALPH_ISSUE_CONTEXT_PREFETCH_TIMEOUT_MS))
+        ? Math.max(0, Math.floor(Number(process.env.RALPH_ISSUE_CONTEXT_PREFETCH_TIMEOUT_MS)))
+        : 1_500;
+      const github = new GitHubClient(repo, { requestTimeoutMs: prefetchTimeoutMs });
+      const raw = await github.getIssue(Number(number));
+      const data = raw && typeof raw === "object" ? (raw as any) : {};
       const metadata: IssueMetadata = {
-        labels: data.labels?.map((l: any) => l.name) ?? [],
-        title: data.title ?? "",
+        labels: Array.isArray(data.labels) ? data.labels.map((l: any) => l?.name ?? "").filter(Boolean) : [],
+        title: typeof data.title === "string" ? data.title : "",
         state: typeof data.state === "string" ? data.state : undefined,
-        stateReason: typeof data.stateReason === "string" ? data.stateReason : undefined,
-        closedAt: typeof data.closedAt === "string" ? data.closedAt : undefined,
-        url: typeof data.url === "string" ? data.url : undefined,
+        stateReason: typeof data.state_reason === "string" ? data.state_reason : undefined,
+        closedAt: typeof data.closed_at === "string" ? data.closed_at : undefined,
+        url: typeof data.html_url === "string" ? data.html_url : undefined,
       };
 
       recordIssueSnapshot({
@@ -3055,6 +3059,99 @@ ${guidance}`
       return metadata;
     } catch {
       return { labels: [], title: "" };
+    }
+  }
+
+  private async buildIssueContextForAgent(params: {
+    repo: string;
+    issueNumber: string | number;
+  }): Promise<string> {
+    const repo = params.repo.trim();
+    const issueNumber = Number(String(params.issueNumber).trim());
+
+    const prefetchTimeoutMs = Number.isFinite(Number(process.env.RALPH_ISSUE_CONTEXT_PREFETCH_TIMEOUT_MS))
+      ? Math.max(0, Math.floor(Number(process.env.RALPH_ISSUE_CONTEXT_PREFETCH_TIMEOUT_MS)))
+      : 1_500;
+
+    if (process.env.BUN_TEST || process.env.NODE_ENV === "test") {
+      return `Issue context (prefetched)\nRepo: ${repo}\nIssue: #${issueNumber}\n\nIssue context prefetch skipped in tests`;
+    }
+
+    if (!Number.isFinite(issueNumber) || issueNumber <= 0) {
+      return `Issue context (prefetched)\nRepo: ${repo}\nIssue: ${String(params.issueNumber).trim()}\n\nIssue context unavailable: invalid issue number`;
+    }
+
+    const truncate = (input: string, maxChars: number): string => {
+      const trimmed = String(input ?? "").trimEnd();
+      if (trimmed.length <= maxChars) return trimmed;
+      return `${trimmed.slice(0, Math.max(0, maxChars - 3)).trimEnd()}...`;
+    };
+
+    try {
+      const github = new GitHubClient(repo, { requestTimeoutMs: prefetchTimeoutMs });
+      const rawIssue = await github.getIssue(issueNumber);
+      const issue = rawIssue && typeof rawIssue === "object" ? (rawIssue as any) : {};
+      const rawComments = await github.listIssueComments(issueNumber, { maxPages: 3, perPage: 100 });
+      const comments = Array.isArray(rawComments) ? rawComments : [];
+
+      const title = typeof issue.title === "string" ? issue.title : "";
+      const url = typeof issue.html_url === "string" ? issue.html_url : "";
+      const state = typeof issue.state === "string" ? issue.state : "";
+      const stateReason = typeof issue.state_reason === "string" ? issue.state_reason : "";
+      const labels = Array.isArray(issue.labels)
+        ? issue.labels.map((l: any) => String(l?.name ?? "").trim()).filter(Boolean)
+        : [];
+      const body = typeof issue.body === "string" ? issue.body : "";
+
+      const parsedComments = comments
+        .map((c: any) => ({
+          author: typeof c?.user?.login === "string" ? c.user.login : "unknown",
+          createdAt: typeof c?.created_at === "string" ? c.created_at : "",
+          url: typeof c?.html_url === "string" ? c.html_url : "",
+          body: typeof c?.body === "string" ? c.body : "",
+        }))
+        .filter((c: any) => c.body || c.createdAt || c.author)
+        .sort((a: any, b: any) => String(a.createdAt).localeCompare(String(b.createdAt)));
+
+      const maxComments = 25;
+      const recent = parsedComments.length > maxComments ? parsedComments.slice(-maxComments) : parsedComments;
+
+      const headerLines = [
+        "Issue context (prefetched)",
+        `Repo: ${repo}`,
+        `Issue: #${issueNumber}`,
+        url ? `URL: ${url}` : null,
+        title ? `Title: ${title}` : null,
+        state ? `State: ${state}${stateReason ? ` (${stateReason})` : ""}` : null,
+        `Labels: ${labels.length ? labels.join(", ") : "(none)"}`,
+      ].filter(Boolean);
+
+      const renderedBody = truncate(sanitizeEscalationReason(body), 12_000);
+
+      const renderedComments = recent
+        .map((c: any) => {
+          const prefix = `- ${c.createdAt || ""} @${c.author}${c.url ? ` (${c.url})` : ""}`.trim();
+          const text = truncate(sanitizeEscalationReason(c.body), 2_000);
+          return [prefix, text ? text : "(empty)", ""].join("\n");
+        })
+        .join("\n");
+
+      return [
+        ...headerLines,
+        "",
+        "Body:",
+        renderedBody || "(empty)",
+        "",
+        "Recent comments:",
+        renderedComments || "(none)",
+      ].join("\n");
+    } catch (error: any) {
+      if (error instanceof GitHubApiError) {
+        const requestId = error.requestId ? ` requestId=${error.requestId}` : "";
+        const resumeAt = error.resumeAtTs ? ` resumeAt=${new Date(error.resumeAtTs).toISOString()}` : "";
+        return `Issue context (prefetched)\nRepo: ${repo}\nIssue: #${issueNumber}\n\nIssue context unavailable: ${error.code} HTTP ${error.status}${requestId}${resumeAt}\n${truncate(error.message, 800)}`;
+      }
+      return `Issue context (prefetched)\nRepo: ${repo}\nIssue: #${issueNumber}\n\nIssue context unavailable: ${truncate(error?.message ?? String(error), 800)}`;
     }
   }
 
@@ -6542,7 +6639,8 @@ ${guidance}`
 
     const attemptCount = claimed.attemptCount;
     await this.recordRunLogPath(params.task, params.issueNumber, "parent-verify", "queued");
-    const prompt = buildParentVerificationPrompt({ repo: this.repo, issueNumber: params.issueNumber });
+    const issueContext = await this.buildIssueContextForAgent({ repo: this.repo, issueNumber: params.issueNumber });
+    const prompt = buildParentVerificationPrompt({ repo: this.repo, issueNumber: params.issueNumber, issueContext });
     let result: SessionResult;
     try {
       result = await this.session.runAgent(this.repoPath, "ralph-parent-verify", prompt, {
@@ -8644,7 +8742,8 @@ ${guidance}`
       const pausedPlan = await this.pauseIfHardThrottled(task, "plan");
       if (pausedPlan) return pausedPlan;
 
-      const plannerPrompt = buildPlannerPrompt({ repo: this.repo, issueNumber });
+      const issueContext = await this.buildIssueContextForAgent({ repo: this.repo, issueNumber });
+      const plannerPrompt = buildPlannerPrompt({ repo: this.repo, issueNumber, issueContext });
       const planRunLogPath = await this.recordRunLogPath(task, issueNumber, "plan", "starting");
 
       let planResult = await this.session.runAgent(taskRepoPath, "ralph-plan", plannerPrompt, {


### PR DESCRIPTION
## What changed
- Prefetch GitHub issue context for `ralph-plan` and `ralph-parent-verify` prompts so agents don't need to run `gh issue view` (GraphQL).
- Switch metadata fetch to REST via `GitHubClient` and add REST fallback commands (`gh api ...`) in prompts.
- Add a safe one-time retry on HTTP 401 by invalidating the cached GitHub App installation token and re-minting.
- Add request timeout support to `GitHubClient` (configurable via `RALPH_GITHUB_REQUEST_TIMEOUT_MS`).

## Why
Issue #245 showed Ralph escalating because the plan agent couldn't read the issue thread (GraphQL timeouts + installation rate limit). This makes the “read the issue” step less brittle and makes auth failures recover faster.

## Notes
- Issue context prefetch is skipped under `bun test` to avoid accidental network calls in integration harness tests.

## Testing
From the worktree:
```bash
cd ../worktree-ralph-github-read-resilience
rm -f /tmp/ralph-global-test.lock
bun test
bun run typecheck
bun run build
```

Relates to #245