### PR TITLE
Emit github.request telemetry events

### DIFF
--- a/src/__tests__/dashboard-event-bus.test.ts
+++ b/src/__tests__/dashboard-event-bus.test.ts
@@ -122,4 +122,31 @@ describe("dashboard event schema", () => {
 
     expect(isRalphEvent(bad)).toBe(false);
   });
+
+  test("validates github.request payload", () => {
+    const ok = buildRalphEvent({
+      type: "github.request",
+      level: "info",
+      repo: "3mdistal/ralph",
+      data: {
+        method: "GET",
+        path: "/repos/3mdistal/ralph/issues/1",
+        status: 200,
+        ok: true,
+        write: false,
+        durationMs: 12,
+        attempt: 1,
+        requestId: "ABC:123",
+      },
+    });
+
+    expect(isRalphEvent(ok)).toBe(true);
+
+    const bad: any = {
+      ...ok,
+      data: { ...ok.data, durationMs: -1 },
+    };
+
+    expect(isRalphEvent(bad)).toBe(false);
+  });
 });

--- a/src/dashboard/events.ts
+++ b/src/dashboard/events.ts
@@ -3,6 +3,7 @@ export type RalphEventLevel = "debug" | "info" | "warn" | "error";
 export type RalphEventType =
   | "daemon.started"
   | "daemon.stopped"
+  | "github.request"
   | "worker.created"
   | "worker.became_busy"
   | "worker.became_idle"
@@ -54,6 +55,37 @@ export type RalphEventEnvelope<TType extends RalphEventType, TData extends objec
 export type RalphEvent =
   | RalphEventEnvelope<"daemon.started", { version?: string }>
   | RalphEventEnvelope<"daemon.stopped", { reason?: string; code?: number }>
+  | RalphEventEnvelope<
+      "github.request",
+      {
+        method: string;
+        path: string;
+        status: number;
+        ok: boolean;
+        write: boolean;
+        durationMs: number;
+        attempt: number;
+        requestId?: string | null;
+        allowNotFound?: boolean;
+        graphqlOperation?: "query" | "mutation" | null;
+        backoffWaitMs?: number;
+        backoffResumeAtTs?: number | null;
+        backoffSetUntilTs?: number | null;
+        rateLimited?: boolean;
+        secondaryRateLimited?: boolean;
+        installationId?: string | null;
+        retryAfterMs?: number | null;
+        willRetry?: boolean;
+        rateLimit?: {
+          limit?: number | null;
+          remaining?: number | null;
+          used?: number | null;
+          resetAtTs?: number | null;
+          resource?: string | null;
+        };
+        errorCode?: string;
+      }
+    >
   | RalphEventEnvelope<"worker.created", { worktreePath?: string; repoSlot?: number }>
   | RalphEventEnvelope<"worker.became_busy", { taskName?: string; issue?: string }>
   | RalphEventEnvelope<"worker.became_idle", { reason?: string }>
@@ -84,6 +116,7 @@ export type RalphEvent =
 const EVENT_TYPES: ReadonlySet<string> = new Set<string>([
   "daemon.started",
   "daemon.stopped",
+  "github.request",
   "worker.created",
   "worker.became_busy",
   "worker.became_idle",
@@ -165,6 +198,39 @@ export function isRalphEvent(value: unknown): value is RalphEvent {
 
   if (type === "worker.checkpoint.reached") {
     return isRalphCheckpoint((data as any).checkpoint);
+  }
+
+  if (type === "github.request") {
+    const method = (data as any).method;
+    const path = (data as any).path;
+    const status = (data as any).status;
+    const ok = (data as any).ok;
+    const write = (data as any).write;
+    const durationMs = (data as any).durationMs;
+    const attempt = (data as any).attempt;
+
+    if (typeof method !== "string" || !method.trim()) return false;
+    if (typeof path !== "string" || !path.trim()) return false;
+    if (typeof status !== "number" || !Number.isFinite(status)) return false;
+    if (typeof ok !== "boolean") return false;
+    if (typeof write !== "boolean") return false;
+    if (typeof durationMs !== "number" || !Number.isFinite(durationMs) || durationMs < 0) return false;
+    if (typeof attempt !== "number" || !Number.isFinite(attempt) || attempt < 1) return false;
+
+    const graphqlOperation = (data as any).graphqlOperation;
+    if (
+      graphqlOperation !== undefined &&
+      graphqlOperation !== null &&
+      graphqlOperation !== "query" &&
+      graphqlOperation !== "mutation"
+    ) {
+      return false;
+    }
+
+    const rateLimit = (data as any).rateLimit;
+    if (rateLimit !== undefined && rateLimit !== null && !isObject(rateLimit)) return false;
+
+    return true;
   }
 
   if (type === "worker.pause.reached") {

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -2,6 +2,7 @@ import type { ExistingLabelSpec, LabelSpec } from "../github-labels";
 import { getProfile, getSandboxProfileConfig } from "../config";
 import { resolveGitHubToken } from "../github-auth";
 import { invalidateInstallationTokenCache } from "../github-app-auth";
+import { publishDashboardEvent } from "../dashboard/publisher";
 import { Semaphore, type ReleaseFn } from "../semaphore";
 import { SandboxTripwireError, assertSandboxWriteAllowed } from "./sandbox-tripwire";
 
@@ -80,6 +81,20 @@ function readEnvInt(name: string, fallback: number): number {
 function clampConcurrency(value: number, fallback: number): number {
   if (!Number.isFinite(value) || value <= 0) return fallback;
   return Math.floor(value);
+}
+
+function clamp01(value: number, fallback: number): number {
+  if (!Number.isFinite(value)) return fallback;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+function readEnvFloat(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : fallback;
 }
 
 function fnv1a32(input: string): string {
@@ -167,6 +182,26 @@ function safeJsonParse<T>(text: string): T | null {
     return JSON.parse(text) as T;
   } catch {
     return null;
+  }
+}
+
+function parseHeaderInt(headers: Headers, name: string): number | null {
+  const raw = headers.get(name);
+  if (!raw) return null;
+  const parsed = Number(raw.trim());
+  if (!Number.isFinite(parsed)) return null;
+  return Math.floor(parsed);
+}
+
+function sanitizeGitHubPath(path: string): string {
+  const raw = String(path ?? "");
+  if (!raw) return "/";
+  try {
+    const url = new URL(`https://api.github.com${raw.startsWith("/") ? "" : "/"}${raw}`);
+    return url.pathname || "/";
+  } catch {
+    const trimmed = raw.startsWith("/") ? raw : `/${raw}`;
+    return trimmed.split("?")[0].split("#")[0] || "/";
   }
 }
 
@@ -261,16 +296,74 @@ export class GitHubClient {
     return keys;
   }
 
-  private async waitForBackoff(tokenKey?: string | null): Promise<void> {
+  private async waitForBackoffWithInfo(tokenKey?: string | null): Promise<{ waitedMs: number; resumeAtTs: number | null }> {
     let resumeAt = 0;
     for (const key of this.getBackoffKeys(tokenKey)) {
       const until = GitHubClient.backoffUntilByKey.get(key) ?? 0;
       if (until > resumeAt) resumeAt = until;
     }
     const now = Date.now();
-    if (resumeAt <= now) return;
+    if (resumeAt <= now) return { waitedMs: 0, resumeAtTs: null };
     const delayMs = Math.min(resumeAt - now, 20 * 60_000);
     await this.sleepMsImpl(delayMs);
+    return { waitedMs: delayMs, resumeAtTs: resumeAt };
+  }
+
+  private shouldEmitRequestTelemetry(params: { ok: boolean; write: boolean; rateLimited: boolean; backoffWaitMs: number }): boolean {
+    if (!params.ok) return true;
+    if (params.rateLimited) return true;
+    if (params.backoffWaitMs > 0) return true;
+    if (params.write) return true;
+
+    const rate = clamp01(readEnvFloat("RALPH_GITHUB_REQUEST_TELEMETRY_SAMPLE_RATE", 0.02), 0.02);
+    return Math.random() < rate;
+  }
+
+  private emitRequestTelemetry(event: {
+    method: string;
+    path: string;
+    status: number;
+    ok: boolean;
+    write: boolean;
+    durationMs: number;
+    attempt: number;
+    requestId?: string | null;
+    allowNotFound?: boolean;
+    graphqlOperation?: "query" | "mutation" | null;
+    backoffWaitMs?: number;
+    backoffResumeAtTs?: number | null;
+    backoffSetUntilTs?: number | null;
+    rateLimited?: boolean;
+    secondaryRateLimited?: boolean;
+    installationId?: string | null;
+    retryAfterMs?: number | null;
+    willRetry?: boolean;
+    rateLimit?: {
+      limit?: number | null;
+      remaining?: number | null;
+      used?: number | null;
+      resetAtTs?: number | null;
+      resource?: string | null;
+    };
+    errorCode?: string;
+  }): void {
+    const status = typeof event.status === "number" ? event.status : 0;
+    const rateLimited = Boolean(event.rateLimited);
+    const ok = Boolean(event.ok);
+    const level = !ok ? (status >= 500 || status === 0 ? "error" : "warn") : rateLimited ? "warn" : "debug";
+
+    try {
+      publishDashboardEvent(
+        {
+          type: "github.request",
+          level,
+          data: event,
+        },
+        { repo: this.repo }
+      );
+    } catch {
+      // Best-effort: telemetry must never break request flow.
+    }
   }
 
   private recordBackoff(params: { untilTs: number; installationId?: string | null; tokenKey?: string | null }): void {
@@ -307,6 +400,8 @@ export class GitHubClient {
   private async requestInternal<T>(path: string, opts: RequestOptions = {}): Promise<GitHubResponse<T> & { headers: Headers }> {
     const url = `https://api.github.com${path.startsWith("/") ? "" : "/"}${path}`;
     const method = (opts.method ?? "GET").toUpperCase();
+    const sanitizedPath = sanitizeGitHubPath(path);
+    const graphqlOperation = isGraphqlPath(path) ? getGraphqlOperation(opts.body) : null;
     const profile = getProfile();
     if (profile === "sandbox" && method !== "GET" && method !== "HEAD") {
       if (isGraphqlPath(path)) {
@@ -346,7 +441,8 @@ export class GitHubClient {
     for (let attempt = 0; attempt < 2; attempt += 1) {
       const token = this.tokenOverride ?? (await this.getToken());
       const tokenKey = token ? fnv1a32(token) : null;
-      await this.waitForBackoff(tokenKey);
+      const backoffInfo = await this.waitForBackoffWithInfo(tokenKey);
+      const startedAt = Date.now();
 
       const init: RequestInit = {
         method,
@@ -376,10 +472,32 @@ export class GitHubClient {
       try {
         res = await fetch(url, init);
       } catch (error: any) {
+        const durationMs = Math.max(0, Date.now() - startedAt);
         const aborted = error?.name === "AbortError" || error?.code === "ABORT_ERR";
         const message = aborted
           ? `GitHub API ${method} ${path} timed out after ${this.requestTimeoutMs}ms.`
           : `GitHub API ${method} ${path} request failed. ${error?.message ?? String(error)}`;
+
+        const ok = false;
+        const rateLimited = false;
+        const shouldEmit = this.shouldEmitRequestTelemetry({ ok, write: isWrite, rateLimited, backoffWaitMs: backoffInfo.waitedMs });
+        if (shouldEmit) {
+          this.emitRequestTelemetry({
+            method,
+            path: sanitizedPath,
+            status: 0,
+            ok,
+            write: isWrite,
+            durationMs,
+            attempt: attempt + 1,
+            allowNotFound: Boolean(opts.allowNotFound),
+            graphqlOperation,
+            backoffWaitMs: backoffInfo.waitedMs,
+            backoffResumeAtTs: backoffInfo.resumeAtTs,
+            errorCode: "network",
+          });
+        }
+
         throw new GitHubApiError({
           message,
           code: "unknown",
@@ -394,28 +512,92 @@ export class GitHubClient {
         releaseRequest();
       }
 
+      const durationMs = Math.max(0, Date.now() - startedAt);
+
       if (opts.allowNotFound && res.status === 404) {
+        const ok = true;
+        const rateLimited = false;
+        const shouldEmit = this.shouldEmitRequestTelemetry({ ok, write: isWrite, rateLimited, backoffWaitMs: backoffInfo.waitedMs });
+        if (shouldEmit) {
+          this.emitRequestTelemetry({
+            method,
+            path: sanitizedPath,
+            status: res.status,
+            ok,
+            write: isWrite,
+            durationMs,
+            attempt: attempt + 1,
+            requestId: res.headers.get("x-github-request-id"),
+            allowNotFound: true,
+            graphqlOperation,
+            backoffWaitMs: backoffInfo.waitedMs,
+            backoffResumeAtTs: backoffInfo.resumeAtTs,
+            rateLimit: {
+              limit: parseHeaderInt(res.headers, "x-ratelimit-limit"),
+              remaining: parseHeaderInt(res.headers, "x-ratelimit-remaining"),
+              used: parseHeaderInt(res.headers, "x-ratelimit-used"),
+              resetAtTs: parseRateLimitResetMs(res.headers),
+              resource: res.headers.get("x-ratelimit-resource"),
+            },
+          });
+        }
+
         return { data: null, etag: res.headers.get("etag"), status: res.status, headers: res.headers };
       }
 
       const text = await res.text();
 
       if (!res.ok) {
-        if (res.status === 401 && attempt === 0 && !this.tokenOverride && invalidateInstallationTokenCache()) {
-          continue;
-        }
-
-        const baseCode = classifyStatus(res.status);
         const retryAfterMs = parseRetryAfterMs(res.headers);
         const resetMs = parseRateLimitResetMs(res.headers);
         const remaining = res.headers.get("x-ratelimit-remaining");
         const remainingZero = typeof remaining === "string" && remaining.trim() === "0";
+        const secondaryRateLimited = isSecondaryRateLimitText(text);
         const isRateLimited =
           res.status === 429 ||
           retryAfterMs != null ||
-          isSecondaryRateLimitText(text) ||
+          secondaryRateLimited ||
           (res.status === 403 && (isPrimaryRateLimitText(text) || remainingZero));
 
+        if (res.status === 401 && attempt === 0 && !this.tokenOverride && invalidateInstallationTokenCache()) {
+          const shouldEmit = this.shouldEmitRequestTelemetry({
+            ok: false,
+            write: isWrite,
+            rateLimited: isRateLimited,
+            backoffWaitMs: backoffInfo.waitedMs,
+          });
+          if (shouldEmit) {
+            this.emitRequestTelemetry({
+              method,
+              path: sanitizedPath,
+              status: res.status,
+              ok: false,
+              write: isWrite,
+              durationMs,
+              attempt: attempt + 1,
+              requestId: res.headers.get("x-github-request-id"),
+              allowNotFound: Boolean(opts.allowNotFound),
+              graphqlOperation,
+              backoffWaitMs: backoffInfo.waitedMs,
+              backoffResumeAtTs: backoffInfo.resumeAtTs,
+              rateLimited: isRateLimited,
+              secondaryRateLimited,
+              retryAfterMs,
+              rateLimit: {
+                limit: parseHeaderInt(res.headers, "x-ratelimit-limit"),
+                remaining: parseHeaderInt(res.headers, "x-ratelimit-remaining"),
+                used: parseHeaderInt(res.headers, "x-ratelimit-used"),
+                resetAtTs: resetMs,
+                resource: res.headers.get("x-ratelimit-resource"),
+              },
+              errorCode: "auth",
+              willRetry: true,
+            });
+          }
+          continue;
+        }
+
+        const baseCode = classifyStatus(res.status);
         const code: GitHubErrorCode = isRateLimited ? "rate_limit" : baseCode;
 
         let untilTs: number | null = null;
@@ -433,6 +615,45 @@ export class GitHubClient {
           this.recordBackoff({ untilTs, installationId: extractInstallationId(text), tokenKey });
         }
 
+        const installId = extractInstallationId(text);
+        if (installId) this.installationId = installId;
+
+        const shouldEmit = this.shouldEmitRequestTelemetry({
+          ok: false,
+          write: isWrite,
+          rateLimited: isRateLimited,
+          backoffWaitMs: backoffInfo.waitedMs,
+        });
+        if (shouldEmit) {
+          this.emitRequestTelemetry({
+            method,
+            path: sanitizedPath,
+            status: res.status,
+            ok: false,
+            write: isWrite,
+            durationMs,
+            attempt: attempt + 1,
+            requestId: res.headers.get("x-github-request-id"),
+            allowNotFound: Boolean(opts.allowNotFound),
+            graphqlOperation,
+            backoffWaitMs: backoffInfo.waitedMs,
+            backoffResumeAtTs: backoffInfo.resumeAtTs,
+            backoffSetUntilTs: untilTs,
+            rateLimited: isRateLimited,
+            secondaryRateLimited,
+            installationId: installId ?? this.installationId,
+            retryAfterMs,
+            rateLimit: {
+              limit: parseHeaderInt(res.headers, "x-ratelimit-limit"),
+              remaining: parseHeaderInt(res.headers, "x-ratelimit-remaining"),
+              used: parseHeaderInt(res.headers, "x-ratelimit-used"),
+              resetAtTs: resetMs,
+              resource: res.headers.get("x-ratelimit-resource"),
+            },
+            errorCode: code,
+          });
+        }
+
         const resumeAt = untilTs != null && untilTs > Date.now() ? ` resumeAt=${new Date(untilTs).toISOString()}` : "";
 
         const missingTokenHint =
@@ -446,6 +667,35 @@ export class GitHubClient {
           responseText: text,
           resumeAtTs: untilTs,
         });
+      }
+
+      {
+        const ok = true;
+        const rateLimited = false;
+        const shouldEmit = this.shouldEmitRequestTelemetry({ ok, write: isWrite, rateLimited, backoffWaitMs: backoffInfo.waitedMs });
+        if (shouldEmit) {
+          this.emitRequestTelemetry({
+            method,
+            path: sanitizedPath,
+            status: res.status,
+            ok,
+            write: isWrite,
+            durationMs,
+            attempt: attempt + 1,
+            requestId: res.headers.get("x-github-request-id"),
+            allowNotFound: Boolean(opts.allowNotFound),
+            graphqlOperation,
+            backoffWaitMs: backoffInfo.waitedMs,
+            backoffResumeAtTs: backoffInfo.resumeAtTs,
+            rateLimit: {
+              limit: parseHeaderInt(res.headers, "x-ratelimit-limit"),
+              remaining: parseHeaderInt(res.headers, "x-ratelimit-remaining"),
+              used: parseHeaderInt(res.headers, "x-ratelimit-used"),
+              resetAtTs: parseRateLimitResetMs(res.headers),
+              resource: res.headers.get("x-ratelimit-resource"),
+            },
+          });
+        }
       }
 
       return {


### PR DESCRIPTION
## Summary
- Adds a new persisted dashboard event type, `github.request`, for per-request GitHub API telemetry.
- Emits events from `GitHubClient.requestInternal()`:
  - always on failures
  - always on writes
  - always when a request waits on backoff
  - sampled on successful read requests (default 2%; configurable via `RALPH_GITHUB_REQUEST_TELEMETRY_SAMPLE_RATE`).
- Redacts query strings by logging only URL pathnames.

## Why
Ralph currently detects rate limits but doesn’t persist enough per-request data to audit which endpoints/flows are consuming GitHub quota or triggering abuse/secondary limits.

## Testing
- `cd /home/teenylilmonkey/Developer/worktree-issue-522`
- `bun test`

Fixes #522