### PR TITLE
fix: dedupe blocked label sync writes

### DIFF
--- a/src/__tests__/blocked-sync.test.ts
+++ b/src/__tests__/blocked-sync.test.ts
@@ -5,7 +5,7 @@ import { join } from "path";
 
 import { RepoWorker } from "../worker";
 import type { IssueRelationshipProvider, IssueRelationshipSnapshot } from "../github/issue-relationships";
-import { closeStateDbForTests, getParentVerificationState, initStateDb } from "../state";
+import { closeStateDbForTests, getParentVerificationState, initStateDb, recordIssueLabelsSnapshot } from "../state";
 import { acquireGlobalTestLock } from "./helpers/test-lock";
 
 const updateTaskStatusMock = mock(async () => true);
@@ -83,6 +83,56 @@ describe("syncBlockedStateForTasks", () => {
     expect(typeof call?.[2]?.["blocked-at"]).toBe("string");
     expect(call?.[2]?.["blocked-at"]).not.toBe("");
     expect(typeof call?.[2]?.["blocked-details"]).toBe("string");
+  });
+
+  test("does not re-add blocked label when already present in state", async () => {
+    updateTaskStatusMock.mockClear();
+    const releaseLock = await acquireGlobalTestLock();
+    const priorStateDb = process.env.RALPH_STATE_DB_PATH;
+    const stateDir = await mkdtemp(join(tmpdir(), "ralph-state-"));
+    process.env.RALPH_STATE_DB_PATH = join(stateDir, "state.sqlite");
+    closeStateDbForTests();
+    initStateDb();
+
+    try {
+      recordIssueLabelsSnapshot({
+        repo: "3mdistal/ralph",
+        issue: "3mdistal/ralph#10",
+        labels: ["ralph:status:blocked"],
+      });
+
+      const provider: IssueRelationshipProvider = {
+        getSnapshot: async (issue): Promise<IssueRelationshipSnapshot> => ({
+          issue,
+          signals: [
+            { source: "github", kind: "blocked_by", state: "open", ref: { repo: issue.repo, number: 11 } },
+          ],
+          coverage: { githubDepsComplete: true, githubSubIssuesComplete: true, bodyDeps: false },
+        }),
+      };
+
+      const worker = new RepoWorker("3mdistal/ralph", "/tmp", {
+        session: sessionAdapter,
+        queue: queueAdapter,
+        notify: notifyAdapter,
+        throttle: throttleAdapter,
+        relationships: provider,
+      });
+
+      const addIssueLabelMock = mock(async () => {});
+      (worker as any).addIssueLabel = addIssueLabelMock;
+
+      await worker.syncBlockedStateForTasks([createTask({})]);
+      await worker.syncBlockedStateForTasks([createTask({})]);
+
+      expect(addIssueLabelMock).not.toHaveBeenCalled();
+    } finally {
+      closeStateDbForTests();
+      if (priorStateDb === undefined) delete process.env.RALPH_STATE_DB_PATH;
+      else process.env.RALPH_STATE_DB_PATH = priorStateDb;
+      await rm(stateDir, { recursive: true, force: true });
+      releaseLock();
+    }
   });
 
   test("does not unblock tasks blocked for other reasons", async () => {


### PR DESCRIPTION
## Why
We observed a high GitHub write rate (thousands of label writes in ~10 minutes) even after fixing the 404 remove convergence bug.

Telemetry showed repeated:
- POST /repos/.../issues/<n>/labels (many times for the same issues)
- DELETE /repos/.../issues/<n>/labels/ralph:status:blocked (404s repeated)

Root cause is RepoWorker.syncBlockedStateForTasks:
- It is invoked frequently, and it would add/remove ralph:status:blocked without first checking whether the label was already present/absent.
- It also did not update Ralph's local issue-label snapshot after successful label ops, so it could keep retrying (especially for 404 deletes).

## What changed
- Record local label snapshots after worker label ops (add/remove) using the applied delta.
- In syncBlockedStateForTasks, skip label writes when state DB is initialized and the label state already matches (still attempts once when state is unavailable).

## Testing
- bun test