### PR TITLE
fix: prevent stale in-progress recovery thrash after fresh claim

### DIFF
--- a/src/github-queue/io.ts
+++ b/src/github-queue/io.ts
@@ -42,6 +42,7 @@ const SWEEP_INTERVAL_MS = 5 * 60_000;
 const WATCH_MIN_INTERVAL_MS = 1000;
 
 const DEFAULT_BLOCKED_SWEEP_MAX_ISSUES_PER_REPO = 25;
+const DEFAULT_MISSING_SESSION_GRACE_MS = 2 * 60_000;
 
 function readEnvInt(name: string, fallback: number): number {
   const raw = process.env[name];
@@ -51,8 +52,21 @@ function readEnvInt(name: string, fallback: number): number {
   return Math.floor(parsed);
 }
 
+function readEnvNonNegativeInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.floor(parsed);
+}
+
 function clampPositiveInt(value: number, fallback: number): number {
   if (!Number.isFinite(value) || value <= 0) return fallback;
+  return Math.floor(value);
+}
+
+function clampNonNegativeInt(value: number, fallback: number): number {
+  if (!Number.isFinite(value) || value < 0) return fallback;
   return Math.floor(value);
 }
 
@@ -464,6 +478,10 @@ export function createGitHubQueueDriver(deps?: GitHubQueueDeps) {
     lastSweepAt = nowMs;
 
     const ttlMs = getConfig().ownershipTtlMs;
+    const missingSessionGraceMs = clampNonNegativeInt(
+      readEnvNonNegativeInt("RALPH_GITHUB_QUEUE_MISSING_SESSION_GRACE_MS", DEFAULT_MISSING_SESSION_GRACE_MS),
+      DEFAULT_MISSING_SESSION_GRACE_MS
+    );
     const nowIso = getNowIso(deps);
 
     for (const repo of getConfig().repos.map((entry) => entry.name)) {
@@ -484,6 +502,7 @@ export function createGitHubQueueDriver(deps?: GitHubQueueDeps) {
           opState,
           nowMs,
           ttlMs,
+          graceMs: missingSessionGraceMs,
         });
         if (!recovery.shouldRecover) continue;
 


### PR DESCRIPTION
Fixes #538

## What changed
- Add a grace period before recovering `ralph:status:in-progress` issues with missing `sessionId`.
- Thread grace through the GitHub queue sweep via `RALPH_GITHUB_QUEUE_MISSING_SESSION_GRACE_MS` (default: 2m).
- Add unit tests for before/after grace behavior.

## Why
Daemon startup/first poll can race with a fresh claim, where labels are already `in-progress` but the local op-state hasn't recorded a `sessionId` yet. Without a grace window this triggers immediate "stale" recovery, causing queued/in-progress label flapping and unnecessary GitHub writes.

## Testing
- bun test