### PR TITLE
fix: bootstrap GitHub workflow labels on initial poll

### DIFF
--- a/src/__tests__/github-queue-label-bootstrap.test.ts
+++ b/src/__tests__/github-queue-label-bootstrap.test.ts
@@ -35,7 +35,7 @@ describe("GitHub queue label bootstrap", () => {
     releaseLock = null;
   });
 
-  test("does not ensure workflow labels during initial poll when no label mutations occur", async () => {
+  test("ensures workflow labels during initial poll", async () => {
     await writeJson(getRalphConfigJsonPath(), {
       queueBackend: "github",
       repos: [{ name: "3mdistal/bwrb", path: "/tmp/bwrb" }],
@@ -66,6 +66,6 @@ describe("GitHub queue label bootstrap", () => {
     });
 
     await driver.initialPoll();
-    expect(ensureCalls).toEqual([]);
+    expect(ensureCalls).toEqual(["3mdistal/bwrb"]);
   });
 });

--- a/src/github-queue/io.ts
+++ b/src/github-queue/io.ts
@@ -691,6 +691,13 @@ export function createGitHubQueueDriver(deps?: GitHubQueueDeps) {
   return {
     name: "github" as const,
     initialPoll: async (): Promise<QueueTask[]> => {
+      // Bootstrap required workflow labels early so new repos become schedulable
+      // before any claim/write attempts.
+      const repos = getConfig().repos.map((entry) => entry.name);
+      if (repos.length > 0) {
+        await Promise.allSettled(repos.map(async (repo) => await io.ensureWorkflowLabels(repo)));
+      }
+
       await maybeSweepStaleInProgress();
       return await listTasksByStatus("queued");
     },

--- a/src/github/escalation-consultant-writeback.ts
+++ b/src/github/escalation-consultant-writeback.ts
@@ -38,7 +38,7 @@ function buildApprovalInstructions(): string {
     "",
     "Fallback:",
     "- Comment with `RALPH RESOLVED: <guidance>`",
-    "- Or re-add `ralph:queued`",
+    "- Or re-add `ralph:status:queued`",
     "",
   ].join("\n");
 }


### PR DESCRIPTION
Fixes #304

- Ensure required `ralph:status:*` workflow labels are bootstrapped during GitHub queue `initialPoll()`, so new repos become schedulable before any claim/mutation attempts.
- Update the label bootstrap test to reflect the new behavior.
- Fix escalation consultant fallback instructions to reference `ralph:status:queued`.

## Testing
- `bun test src/__tests__/github-queue-label-bootstrap.test.ts`