### PR TITLE
chore: sync main into bot/integration

### DIFF
--- a/src/__tests__/github-queue-label-bootstrap.test.ts
+++ b/src/__tests__/github-queue-label-bootstrap.test.ts
@@ -35,7 +35,7 @@ describe("GitHub queue label bootstrap", () => {
     releaseLock = null;
   });
 
-  test("does not ensure workflow labels during initial poll when no label mutations occur", async () => {
+  test("ensures workflow labels during initial poll", async () => {
     await writeJson(getRalphConfigJsonPath(), {
       queueBackend: "github",
       repos: [{ name: "3mdistal/bwrb", path: "/tmp/bwrb" }],
@@ -66,6 +66,6 @@ describe("GitHub queue label bootstrap", () => {
     });
 
     await driver.initialPoll();
-    expect(ensureCalls).toEqual([]);
+    expect(ensureCalls).toEqual(["3mdistal/bwrb"]);
   });
 });

--- a/src/github/escalation-consultant-writeback.ts
+++ b/src/github/escalation-consultant-writeback.ts
@@ -38,7 +38,7 @@ function buildApprovalInstructions(): string {
     "",
     "Fallback:",
     "- Comment with `RALPH RESOLVED: <guidance>`",
-    "- Or re-add `ralph:queued`",
+    "- Or re-add `ralph:status:queued`",
     "",
   ].join("\n");
 }


### PR DESCRIPTION
Keeps `bot/integration` up to date with `main` so rollup PR #566 can satisfy the "up to date with base" branch protection requirement.