### PR TITLE
Move Ralph devex agent to gpt-5.3-codex

### DIFF
--- a/src/opencode-managed-config/templates/opencode.json
+++ b/src/opencode-managed-config/templates/opencode.json
@@ -22,7 +22,7 @@
     },
     "devex": {
       "description": "Developer experience advisor",
-      "model": "openai/gpt-5.2",
+      "model": "openai/gpt-5.3-codex",
       "prompt": "agent/devex.md",
       "mode": "subagent"
     }


### PR DESCRIPTION
## Summary
- update the managed OpenCode `devex` agent model from `openai/gpt-5.2` to `openai/gpt-5.3-codex`
- keep all other agent model entries unchanged

## Testing
- bun test src/__tests__/opencode-managed-config.test.ts