### PR TITLE
fix(gh): decode stderr bytes for blocked diagnostics

### DIFF
--- a/src/__tests__/gh-error-format.test.ts
+++ b/src/__tests__/gh-error-format.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+
+import { formatGhError } from "../worker/gh-error-format";
+
+describe("formatGhError", () => {
+  test("includes ghCommand and decodes Uint8Array stderr", () => {
+    const stderrText = "HTTP 405: Required status checks are expected.";
+    const err: any = new Error("ShellError: Failed with exit code 1");
+    err.ghCommand = "gh pr merge 1 --repo 3mdistal/ralph";
+    err.exitCode = 1;
+    err.stderr = new TextEncoder().encode(stderrText);
+
+    const out = formatGhError(err);
+    expect(out).toContain("Command: gh pr merge 1 --repo 3mdistal/ralph");
+    expect(out).toContain("Exit code: 1");
+    expect(out).toContain("stderr:");
+    expect(out).toContain(stderrText);
+
+    // Guard against Uint8Array default .toString() output (comma-separated bytes).
+    expect(out).not.toMatch(/\b\d+(?:,\d+){5,}\b/);
+  });
+
+  test("redacts obvious tokens in stderr", () => {
+    const err: any = new Error("ShellError: Failed with exit code 1");
+    err.ghCommand = "gh api /repos/x/y";
+    err.stderr = "Bad credentials: ghp_abcdefghijklmnopqrstuvwxyz0123456789";
+
+    const out = formatGhError(err);
+    expect(out).toContain("ghp_[REDACTED]");
+    expect(out).not.toContain("ghp_abcdefghijklmnopqrstuvwxyz0123456789");
+  });
+});

--- a/src/worker/gh-error-format.ts
+++ b/src/worker/gh-error-format.ts
@@ -1,0 +1,74 @@
+import { redactSensitiveText } from "../redaction";
+
+import { summarizeForNote } from "./run-notes";
+
+function stringifyText(value: unknown): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value.trim();
+
+  // Bun ShellError frequently uses Uint8Array for stdout/stderr.
+  // Calling .toString() on Uint8Array returns a comma-separated byte list,
+  // so decode as UTF-8 first.
+  if (value instanceof Uint8Array) {
+    try {
+      return new TextDecoder("utf-8", { fatal: false }).decode(value).trim();
+    } catch {
+      return "";
+    }
+  }
+
+  if (typeof (value as any)?.toString === "function") {
+    try {
+      return String((value as any).toString()).trim();
+    } catch {
+      return "";
+    }
+  }
+
+  try {
+    return String(value).trim();
+  } catch {
+    return "";
+  }
+}
+
+function stringifyGhOutput(value: unknown): string {
+  const text = stringifyText(value);
+  return text ? redactSensitiveText(text).trim() : "";
+}
+
+export function buildGhErrorSearchText(error: any): string {
+  const parts: string[] = [];
+  const message = String(error?.message ?? "").trim();
+  const stderr = stringifyGhOutput(error?.stderr);
+  const stdout = stringifyGhOutput(error?.stdout);
+
+  if (message) parts.push(message);
+  if (stderr) parts.push(stderr);
+  if (stdout) parts.push(stdout);
+
+  return parts.join("\n").trim();
+}
+
+export function formatGhError(error: any): string {
+  const lines: string[] = [];
+
+  const command = String(error?.ghCommand ?? error?.command ?? "").trim();
+  const redactedCommand = command ? redactSensitiveText(command).trim() : "";
+  if (redactedCommand) lines.push(`Command: ${redactedCommand}`);
+
+  const exitCodeRaw = error?.exitCode ?? error?.code ?? null;
+  const exitCode = exitCodeRaw === null || exitCodeRaw === undefined ? "" : String(exitCodeRaw).trim();
+  if (exitCode) lines.push(`Exit code: ${exitCode}`);
+
+  const message = String(error?.message ?? "").trim();
+  if (message) lines.push(message);
+
+  const stderr = stringifyGhOutput(error?.stderr);
+  const stdout = stringifyGhOutput(error?.stdout);
+
+  if (stderr) lines.push("", "stderr:", summarizeForNote(stderr, 1600));
+  if (stdout) lines.push("", "stdout:", summarizeForNote(stdout, 1600));
+
+  return lines.join("\n").trim();
+}


### PR DESCRIPTION
## Why
Some `gh` failures were bubbling up as low-signal alerts (e.g. only `Failed with exit code 1`) because Bun `ShellError` often provides `stdout`/`stderr` as `Uint8Array`, and the existing formatter would stringify it poorly.

## What Changed
- Decode `Uint8Array` gh `stdout`/`stderr` as UTF-8, redact obvious secrets, and keep excerpts bounded.
- Centralize gh error formatting and use it from `RepoWorker` so blocked diagnostics consistently include `ghCommand` + `stderr`.

## Testing
- `bun test`
- `bun run typecheck`
- `bun run build`
- `bun run knip`

Fixes #644