### PR TITLE
Harden ralphctl daemon discovery vs legacy roots

### DIFF
--- a/.ralph/plan.md
+++ b/.ralph/plan.md
@@ -1,58 +1,33 @@
-# Plan: #605 `ralphctl doctor`
+# Plan: #669 Harden ralphctl daemon discovery vs legacy roots
 
-Goal: add a stable `ralphctl doctor` audit surface for stale discovery/control records, with an explicit, safe, non-destructive repair mode and machine-readable JSON output.
+Issue: https://github.com/3mdistal/ralph/issues/669
 
-Assumptions (based on existing implementation on `feat/605-ralphctl-doctor` + product plan review):
-- CLI v1: `ralphctl doctor [--json] [--repair|--apply] [--dry-run]`
-- Exit codes: `0` iff overall_status==`ok`; `1` if any warn/error findings remain; `2` for usage errors and unexpected internal failures.
-- JSON schema is versioned and additive-only for v1: `schema_version: 1`.
-- Repair mode is opt-in and non-destructive only (no deletes): quarantine via rename-with-suffix; promote live legacy record without overwriting an existing canonical record.
+Assumptions (non-interactive defaults):
+- Identity de-duplication key for daemon records is `(daemonId, pid)`; treat same key across multiple roots as the same live daemon.
+- Fail closed only when there are multiple distinct *live* identities (multiple `(daemonId, pid)` pairs with alive PIDs).
+- Preserve existing CLI exit code conventions; prefer additive JSON/report fields and new finding/repair codes.
 
 ## Checklist
 
-- [x] Inspect existing branch `feat/605-ralphctl-doctor` and confirm scope is already implemented (doctor core + repairs + unit tests) so we only add missing CLI contract coverage + any contract-alignment fixes.
-- [x] Lock down v1 contract in code/tests:
-  - [x] `--json` prints exactly one JSON object to stdout (no extra text)
-  - [x] exit-code matrix is deterministic (0/1/2)
-  - [x] `schema_version: 1` and required top-level fields are always present
-
-- [x] Test isolation hardening (to avoid flake/leakage in CI and parallel Bun runs):
-  - [ ] Use `acquireGlobalTestLock` from `src/__tests__/helpers/test-lock.ts` around CLI spawn tests (HOME/XDG/env are process-global).
-  - [x] Spawn `ralphctl` with an isolated env that sets at least:
-    - [x] `HOME` (temp dir)
-    - [x] `XDG_STATE_HOME` (temp dir) to avoid legacy-path bleed
-    - [x] `RALPH_STATE_DB_PATH`, `RALPH_SESSIONS_DIR`, `RALPH_WORKTREES_DIR` (temp dirs) defensively (even if doctor doesn’t use them)
-  - [x] Restore/cleanup in `finally` and `afterEach` to prevent cross-test contamination.
-
-- [x] Add explicit CLI-level contract tests (spawn `bun src/ralphctl.ts doctor ...`):
-  - [x] `src/__tests__/ralphctl-doctor-cli.test.ts`
-  - [x] Implement a small CLI harness helper in the test file:
-    - [x] `runRalphctl(args, env)` uses `spawnSync(process.execPath, ["src/ralphctl.ts", ...args])` for portability
-    - [x] `assertDoctorJsonV1(payload)` validates required fields/types only (additive schema tolerant)
-  - [x] Fixture: clean/ok state -> exit 0
-  - [x] Fixture: stale daemon record + missing canonical control -> exit 1, findings include stale
-  - [x] Unknown arg/flag -> exit 2 (and no JSON output)
-  - [x] Unexpected internal failure -> exit 2 (deterministic): add a test-only fault hook in the doctor CLI path (env-gated) and assert stdout is not partial/invalid JSON.
-
-- [x] Add repair safety + idempotence CLI tests (filesystem fixtures):
-  - [x] No `--repair`: no mutation; `applied_repairs` empty
-  - [x] `--repair --dry-run`: no mutation; repairs recorded as `skipped`
-  - [x] `--repair` applies only safe actions; quarantine renames the record file with a backup suffix
-  - [x] Repeat `--repair` is idempotent (no additional mutations / no extra `*.stale-*` files)
-  - [x] Live-daemon guard: never quarantine a record whose PID is live (use a real long-lived child process PID for determinism)
-  - [x] Prove "no mutation" by snapshotting directory entries + file contents (hash or exact string) before/after for audit-only and dry-run cases.
-
-- [x] Align implementation to the contract where needed:
-  - [x] Ensure unexpected errors in doctor invocation return exit 2 (not 1)
-  - [x] Ensure promote-to-canonical repair is no-overwrite + idempotent:
-    - [x] If canonical record exists and matches the live legacy record, treat as already satisfied and `skip`
-    - [x] If canonical exists but differs, `skip` with an explicit needs-human reason (no overwrite)
-
-- [x] Documentation touch-up:
-  - [x] `README.md`: add/confirm `ralphctl doctor` usage + contract notes (exit codes, `--json` schema_version v1, repair safety)
-
-- [ ] Preflight locally:
-  - [ ] `bun test`
-  - [x] `bun run typecheck`
-  - [x] `bun run build`
-  - [x] `bun run knip`
+- [x] Read issue + relevant product/docs guidance
+- [x] Consult @product for success criteria
+- [x] Consult @devex for maintainability + risk review
+- [x] Create shared identity analysis core (pure): `src/daemon-identity-core.ts`
+- [x] Add unit tests for identity core (table-driven): duplicates vs conflicts, representative selection tie-breaks
+- [x] Update `src/daemon-discovery.ts` to use identity core:
+- [x] Treat same-daemon duplicates across roots as `state="live"` (not conflict)
+- [x] Fail closed only when multiple distinct live identities are present
+- [x] Keep stale detection/heal behavior intact
+- [x] Update/extend daemon discovery tests:
+- [x] Same-daemon duplicate records across roots => live, canonical chosen as representative
+- [x] Different-daemon live records (distinct identity keys) => conflict
+- [x] Harden doctor reporting in `src/doctor/core.ts` using identity core:
+- [x] Error only on multiple distinct live identities
+- [x] Warn on duplicate live records for the same identity (add new finding code; additive-only)
+- [x] Add repair recommendation(s) for safe de-duplication and legacy control cleanup (additive-only)
+- [x] Implement doctor repair actions in `src/doctor/repair.ts`:
+- [x] Quarantine duplicate daemon record files when safe (prefer keeping canonical; revalidate preconditions at execution time)
+- [x] Provide safe cleanup path for legacy control files only when canonical exists + contents match + no live record references the legacy path
+- [x] Update/extend doctor repair tests + CLI doctor tests for new behavior
+- [x] Run targeted tests: `bun test src/__tests__/daemon-discovery.test.ts src/__tests__/doctor-repair.test.ts src/__tests__/ralphctl-doctor-cli.test.ts`
+- [x] Run full suite (`bun test`) and `bun run typecheck` (full suite currently has unrelated pre-existing hook timeouts in other test files)

--- a/src/__tests__/daemon-identity-core.test.ts
+++ b/src/__tests__/daemon-identity-core.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { analyzeLiveDaemonCandidates } from "../daemon-identity-core";
+
+describe("daemon identity core", () => {
+  test("groups duplicate live records by daemonId+pid and prefers canonical representative", () => {
+    const analysis = analyzeLiveDaemonCandidates([
+      {
+        path: "/tmp/legacy/daemon.json",
+        isCanonical: false,
+        alive: true,
+        record: { daemonId: "d1", pid: 111, startedAt: "2026-02-09T00:00:00.000Z" },
+      },
+      {
+        path: "/home/test/.ralph/control/daemon-registry.json",
+        isCanonical: true,
+        alive: true,
+        record: { daemonId: "d1", pid: 111, startedAt: "2026-02-09T00:00:01.000Z" },
+      },
+    ]);
+
+    expect(analysis.hasConflict).toBeFalse();
+    expect(analysis.distinctLiveIdentities).toBe(1);
+    expect(analysis.duplicateGroups.length).toBe(1);
+    expect(analysis.primaryLiveCandidate?.path).toBe("/home/test/.ralph/control/daemon-registry.json");
+  });
+
+  test("marks conflict when multiple distinct live identities are present", () => {
+    const analysis = analyzeLiveDaemonCandidates([
+      {
+        path: "/home/test/.ralph/control/daemon-registry.json",
+        isCanonical: true,
+        alive: true,
+        record: { daemonId: "d1", pid: 111, startedAt: "2026-02-09T00:00:00.000Z" },
+      },
+      {
+        path: "/tmp/legacy/daemon.json",
+        isCanonical: false,
+        alive: true,
+        record: { daemonId: "d2", pid: 222, startedAt: "2026-02-09T00:00:00.000Z" },
+      },
+    ]);
+
+    expect(analysis.hasConflict).toBeTrue();
+    expect(analysis.distinctLiveIdentities).toBe(2);
+    expect(analysis.primaryLiveCandidate).toBeNull();
+  });
+});

--- a/src/daemon-identity-core.ts
+++ b/src/daemon-identity-core.ts
@@ -1,0 +1,80 @@
+export type DaemonIdentityRecord = {
+  daemonId: string;
+  pid: number;
+  startedAt: string;
+};
+
+export type DaemonIdentityCandidate = {
+  path: string;
+  isCanonical: boolean;
+  alive: boolean;
+  record: DaemonIdentityRecord;
+};
+
+export type DaemonIdentityGroup<T extends DaemonIdentityCandidate> = {
+  key: string;
+  representative: T;
+  candidates: T[];
+};
+
+export type DaemonIdentityAnalysis<T extends DaemonIdentityCandidate> = {
+  liveCandidates: T[];
+  groups: DaemonIdentityGroup<T>[];
+  duplicateGroups: DaemonIdentityGroup<T>[];
+  distinctLiveIdentities: number;
+  hasConflict: boolean;
+  primaryLiveCandidate: T | null;
+};
+
+export function buildDaemonIdentityKey(input: { daemonId: string; pid: number }): string {
+  return `${input.daemonId}:${input.pid}`;
+}
+
+function compareByPreference<T extends DaemonIdentityCandidate>(a: T, b: T): number {
+  if (a.isCanonical && !b.isCanonical) return -1;
+  if (!a.isCanonical && b.isCanonical) return 1;
+
+  const aStarted = Date.parse(a.record.startedAt);
+  const bStarted = Date.parse(b.record.startedAt);
+  if (Number.isFinite(aStarted) && Number.isFinite(bStarted) && aStarted !== bStarted) return bStarted - aStarted;
+  if (Number.isFinite(aStarted) && !Number.isFinite(bStarted)) return -1;
+  if (!Number.isFinite(aStarted) && Number.isFinite(bStarted)) return 1;
+  return a.path.localeCompare(b.path);
+}
+
+export function analyzeLiveDaemonCandidates<T extends DaemonIdentityCandidate>(candidates: T[]): DaemonIdentityAnalysis<T> {
+  const liveCandidates = candidates.filter((candidate) => candidate.alive);
+  const byKey = new Map<string, T[]>();
+
+  for (const candidate of liveCandidates) {
+    const key = buildDaemonIdentityKey(candidate.record);
+    const group = byKey.get(key);
+    if (group) group.push(candidate);
+    else byKey.set(key, [candidate]);
+  }
+
+  const groups = Array.from(byKey.entries())
+    .map(([key, group]) => {
+      const sorted = [...group].sort(compareByPreference);
+      return {
+        key,
+        representative: sorted[0] as T,
+        candidates: sorted,
+      };
+    })
+    .sort((a, b) => compareByPreference(a.representative, b.representative));
+
+  const distinctLiveIdentities = groups.length;
+  const duplicateGroups = groups.filter((group) => group.candidates.length > 1);
+  const hasConflict = distinctLiveIdentities > 1;
+  const primaryLiveCandidate = distinctLiveIdentities === 1 ? groups[0]?.representative ?? null : null;
+
+  return {
+    liveCandidates,
+    groups,
+    duplicateGroups,
+    distinctLiveIdentities,
+    hasConflict,
+    primaryLiveCandidate,
+  };
+}


### PR DESCRIPTION
Fixes #669\n\nThis hardens daemon discovery/doctor so duplicate *records* that refer to the same live daemon identity no longer block control actions, while still failing closed when multiple distinct daemon identities are alive.