### PR TITLE
Harden worktree artifacts: skip-worktree tracked .ralph

### DIFF
--- a/src/__tests__/worktree-artifacts.test.ts
+++ b/src/__tests__/worktree-artifacts.test.ts
@@ -1,0 +1,44 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { $ } from "bun";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { ensureRalphWorktreeArtifacts } from "../worktree-artifacts";
+
+let repoDir: string;
+
+describe("worktree artifacts", () => {
+  beforeEach(async () => {
+    repoDir = await mkdtemp(join(tmpdir(), "ralph-worktree-artifacts-"));
+    await $`git init -q`.cwd(repoDir);
+  });
+
+  afterEach(async () => {
+    await rm(repoDir, { recursive: true, force: true });
+  });
+
+  test("creates plan file and excludes .ralph directory", async () => {
+    const { planPath } = await ensureRalphWorktreeArtifacts(repoDir);
+    expect(planPath).toBe(join(repoDir, ".ralph", "plan.md"));
+
+    const excludePath = join(repoDir, ".git", "info", "exclude");
+    const excludeContents = await readFile(excludePath, "utf8");
+    expect(excludeContents).toContain(".ralph/");
+
+    const planContents = await readFile(planPath, "utf8");
+    expect(planContents).toContain("# Plan");
+  });
+
+  test("marks tracked .ralph files as skip-worktree", async () => {
+    await mkdir(join(repoDir, ".ralph"), { recursive: true });
+    await writeFile(join(repoDir, ".ralph", "plan.md"), "# Plan\n\n- [ ] hi\n", "utf8");
+    await $`git add .ralph/plan.md`.cwd(repoDir);
+
+    await ensureRalphWorktreeArtifacts(repoDir);
+
+    const result = await $`git ls-files -v -- .ralph/plan.md`.cwd(repoDir).quiet();
+    const line = result.stdout.toString().trim();
+    expect(line.startsWith("S ")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why
Ralph writes a worktree-local plan checklist to `.ralph/plan.md`. Ralph already adds `.ralph/` to `.git/info/exclude`, but that does not help if a repo accidentally tracks files under `.ralph/` (ignore rules don't apply to tracked files). This can leak `plan.md` into commits/PRs and cause noisy merge conflicts.

## What changed
- In `src/worktree-artifacts.ts`, detect tracked files under `.ralph/` and mark them `skip-worktree` (best-effort)
- Add tests covering:
  - `.git/info/exclude` entry is ensured
  - tracked `.ralph/plan.md` becomes `skip-worktree`

## Testing
- `bun test src/__tests__/worktree-artifacts.test.ts`