### PR TITLE
Fix PR recovery gating for PR creation

### DIFF
--- a/src/worker/lanes/resume.ts
+++ b/src/worker/lanes/resume.ts
@@ -296,7 +296,11 @@ export async function runResumeLane(deps: ResumeLaneDeps, task: AgentTask, opts?
               if (escalated) {
                 applyTaskPatch(task, "escalated", {});
               }
-              await this.writeEscalationWriteback(task, { reason, escalationType: "other" });
+              await this.writeEscalationWriteback(task, {
+                reason,
+                details: [buildResult.output, prRecoveryDiagnostics].filter(Boolean).join("\n\n"),
+                escalationType: "other",
+              });
               await this.notify.notifyEscalation({
                 taskName: task.name,
                 taskFileName: task._name,
@@ -560,7 +564,11 @@ export async function runResumeLane(deps: ResumeLaneDeps, task: AgentTask, opts?
           if (escalated) {
             applyTaskPatch(task, "escalated", {});
           }
-          await this.writeEscalationWriteback(task, { reason, escalationType: "other" });
+          await this.writeEscalationWriteback(task, {
+            reason,
+            details: [buildResult.output, prRecoveryDiagnostics].filter(Boolean).join("\n\n"),
+            escalationType: "other",
+          });
           await this.notify.notifyEscalation({
             taskName: task.name,
             taskFileName: task._name,

--- a/src/worker/lanes/start.ts
+++ b/src/worker/lanes/start.ts
@@ -631,7 +631,11 @@ export async function runStartLane(deps: StartLaneDeps, task: AgentTask, opts?: 
               if (escalated) {
                 applyTaskPatch(task, "escalated", {});
               }
-              await this.writeEscalationWriteback(task, { reason, escalationType: "other" });
+              await this.writeEscalationWriteback(task, {
+                reason,
+                details: [buildResult.output, prRecoveryDiagnostics].filter(Boolean).join("\n\n"),
+                escalationType: "other",
+              });
               await this.notify.notifyEscalation({
                 taskName: task.name,
                 taskFileName: task._name,
@@ -887,7 +891,11 @@ export async function runStartLane(deps: StartLaneDeps, task: AgentTask, opts?: 
           if (escalated) {
             applyTaskPatch(task, "escalated", {});
           }
-          await this.writeEscalationWriteback(task, { reason, escalationType: "other" });
+          await this.writeEscalationWriteback(task, {
+            reason,
+            details: [buildResult.output, prRecoveryDiagnostics].filter(Boolean).join("\n\n"),
+            escalationType: "other",
+          });
           await this.notify.notifyEscalation({
             taskName: task.name,
             taskFileName: task._name,


### PR DESCRIPTION
Fixes #688

PR recovery should be able to deterministically create the PR even when PR-readiness review gates cannot run (e.g., tool-less review agents that cannot read diff artifacts).

## Changes
- Treat PR-readiness Product/DevEx reviews as skipped during PR recovery so `tryEnsurePrFromWorktree()` can still push + open a PR.
- Include PR recovery diagnostics in GitHub escalation writebacks so escalations are actionable.

## Testing
- bun test