### PR TITLE
Fix planner startup stalls and status-label drift recovery

### DIFF
--- a/src/__tests__/github-queue-update-task-status.test.ts
+++ b/src/__tests__/github-queue-update-task-status.test.ts
@@ -395,4 +395,65 @@ describe("GitHub queue updateTaskStatus", () => {
     const labels = stateMod.getIssueLabels("3mdistal/ralph", 407);
     expect(labels).toEqual(["ralph:status:queued"]);
   });
+
+  test("status drift overrides debounce and heals dual queued/in-progress labels", async () => {
+    const now = new Date("2026-02-03T06:00:00.000Z");
+    const queueMod = await import("../github-queue/io");
+    const stateMod = await import("../state");
+    const calls: Array<{ add: string[]; remove: string[] }> = [];
+    const driver = queueMod.createGitHubQueueDriver({
+      now: () => now,
+      io: {
+        ensureWorkflowLabels: async () => ({ ok: true, created: [], updated: [] }),
+        listIssueLabels: async () => ["ralph:status:queued", "ralph:status:in-progress"],
+        fetchIssue: async () => ({
+          title: "Drift",
+          state: "OPEN",
+          url: "https://github.com/3mdistal/ralph/issues/408",
+          githubNodeId: "node-408",
+          githubUpdatedAt: now.toISOString(),
+          labels: ["ralph:status:queued", "ralph:status:in-progress"],
+        }),
+        reopenIssue: async () => {},
+        addIssueLabel: async () => {},
+        addIssueLabels: async () => {},
+        removeIssueLabel: async () => ({ removed: true }),
+        mutateIssueLabels: async ({ add, remove }) => {
+          calls.push({ add, remove });
+          return true;
+        },
+      },
+    });
+
+    const task = buildTask("3mdistal/ralph", 408);
+    stateMod.recordIssueSnapshot({
+      repo: "3mdistal/ralph",
+      issue: "3mdistal/ralph#408",
+      title: "Drift",
+      state: "OPEN",
+      url: "https://github.com/3mdistal/ralph/issues/408",
+      githubUpdatedAt: now.toISOString(),
+      at: now.toISOString(),
+    });
+    stateMod.recordIssueLabelsSnapshot({
+      repo: "3mdistal/ralph",
+      issue: "3mdistal/ralph#408",
+      labels: ["ralph:status:queued", "ralph:status:in-progress"],
+      at: now.toISOString(),
+    });
+    stateMod.recordIssueStatusTransition({
+      repo: "3mdistal/ralph",
+      issueNumber: 408,
+      fromStatus: "queued",
+      toStatus: "in-progress",
+      reason: "update-task-status:queued",
+      updatedAtMs: now.getTime() - 1_000,
+    });
+
+    const updated = await driver.updateTaskStatus(task, "queued");
+    expect(updated).toBe(true);
+    expect(calls).toEqual([{ add: ["ralph:status:queued"], remove: ["ralph:status:in-progress"] }]);
+    const labels = stateMod.getIssueLabels("3mdistal/ralph", 408);
+    expect(labels).toEqual(["ralph:status:queued"]);
+  });
 });

--- a/src/__tests__/session-persistence.test.ts
+++ b/src/__tests__/session-persistence.test.ts
@@ -154,6 +154,16 @@ describe("Session Persistence", () => {
 
       expect(newStatus).toBe("in-progress");
     });
+
+    test("starting task without session should reset to queued on startup", () => {
+      const task = createMockTask({ status: "starting", "session-id": "" });
+
+      // Simulate startup normalization for half-open starting tasks.
+      const hasSession = task["session-id"]?.trim();
+      const newStatus = hasSession ? "starting" : "queued";
+
+      expect(newStatus).toBe("queued");
+    });
   });
 
   describe("Session ID clearing", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1339,6 +1339,19 @@ async function resumeTasksOnStartup(opts?: {
   const awaitCompletion = opts?.awaitCompletion ?? true;
   const schedulingMode = opts?.schedulingMode ?? resumeSchedulingMode;
 
+  const starting = await getTasksByStatus("starting");
+  for (const task of starting) {
+    if (task["session-id"]?.trim()) continue;
+    console.warn(`[ralph] Startup recovery: resetting stale starting task to queued: ${task.name}`);
+    await updateTaskStatus(task, "queued", {
+      "session-id": "",
+      "daemon-id": "",
+      "heartbeat-at": "",
+      "worker-id": "",
+      "repo-slot": "",
+    });
+  }
+
   const inProgress = await getTasksByStatus("in-progress");
 
   if (inProgress.length > 0) {

--- a/src/queue/types.ts
+++ b/src/queue/types.ts
@@ -52,6 +52,8 @@ export interface QueueTask {
   "watchdog-retries"?: string;
   /** Stall recovery attempts (string in frontmatter) */
   "stall-retries"?: string;
+  /** Planner bootstrap timeout recovery attempts (string in frontmatter) */
+  "planner-bootstrap-retries"?: string;
   /** Long-run guardrail recovery attempts (string in frontmatter) */
   "guardrail-retries"?: string;
   /** Escalation autopilot loop ledger JSON (signature -> attempts metadata). */

--- a/src/worker/lanes/start.ts
+++ b/src/worker/lanes/start.ts
@@ -227,6 +227,10 @@ export async function runStartLane(deps: StartLaneDeps, task: AgentTask, opts?: 
           return await this.handleWatchdogTimeout(task, cacheKey, "plan", planResult, opencodeXdg);
         }
 
+        if (!planResult.success && planResult.sessionBootstrapTimeout) {
+          return await this.handlePlannerBootstrapTimeout(task, "plan", planResult);
+        }
+
         if (!planResult.success && planResult.stallTimeout) {
           return await this.handleStallTimeout(task, cacheKey, "plan", planResult);
         }
@@ -266,6 +270,10 @@ export async function runStartLane(deps: StartLaneDeps, task: AgentTask, opts?: 
             return await this.handleWatchdogTimeout(task, cacheKey, "plan", planResult, opencodeXdg);
           }
 
+          if (planResult.sessionBootstrapTimeout) {
+            return await this.handlePlannerBootstrapTimeout(task, "plan", planResult);
+          }
+
           if (planResult.stallTimeout) {
             return await this.handleStallTimeout(task, cacheKey, "plan", planResult);
           }
@@ -292,6 +300,7 @@ export async function runStartLane(deps: StartLaneDeps, task: AgentTask, opts?: 
         if (planResult.sessionId) {
           await this.queue.updateTaskStatus(task, "in-progress", {
             "session-id": planResult.sessionId,
+            "planner-bootstrap-retries": "",
             ...(workerId ? { "worker-id": workerId } : {}),
             ...(typeof allocatedSlot === "number" ? { "repo-slot": String(allocatedSlot) } : {}),
           });

--- a/src/worker/repo-worker.ts
+++ b/src/worker/repo-worker.ts
@@ -4733,6 +4733,12 @@ export class RepoWorker {
     return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
   }
 
+  private getPlannerBootstrapRetryCount(task: AgentTask): number {
+    const raw = task["planner-bootstrap-retries"];
+    const parsed = Number.parseInt(String(raw ?? "0"), 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+  }
+
   private buildWatchdogOptions(task: AgentTask, stage: string) {
     const cfg = getConfig().watchdog;
     const context = `[${this.repo}] ${task.name} (${task.issue}) stage=${stage}`;
@@ -4752,11 +4758,17 @@ export class RepoWorker {
     const cfg = getConfig().stall;
     const context = `[${this.repo}] ${task.name} (${task.issue}) stage=${stage}`;
     const idleMs = cfg?.nudgeAfterMs ?? cfg?.idleMs ?? 5 * 60_000;
+    const sessionBootstrapTimeoutMs = Number.parseInt(process.env.RALPH_SESSION_BOOTSTRAP_TIMEOUT_MS ?? "", 10);
+    const sessionBootstrapMs =
+      Number.isFinite(sessionBootstrapTimeoutMs) && sessionBootstrapTimeoutMs > 0
+        ? sessionBootstrapTimeoutMs
+        : Math.max(60_000, idleMs);
 
     return {
       stall: {
         enabled: cfg?.enabled ?? true,
         idleMs,
+        sessionBootstrapMs,
         context,
       },
     };
@@ -5146,6 +5158,95 @@ export class RepoWorker {
       outcome: "escalated",
       sessionId: result.sessionId || undefined,
       escalationReason: escalationReason,
+    };
+  }
+
+  private async handlePlannerBootstrapTimeout(task: AgentTask, stage: string, result: SessionResult): Promise<AgentRun> {
+    const cfg = getConfig().stall;
+    const maxRestarts = cfg?.maxRestarts ?? 1;
+
+    const timeout = result.sessionBootstrapTimeout;
+    const retryCount = this.getPlannerBootstrapRetryCount(task);
+    const nextRetryCount = retryCount + 1;
+
+    const elapsedSeconds = timeout ? Math.max(1, Math.round(timeout.elapsedMs / 1000)) : 0;
+    const reason = timeout
+      ? `Planner session bootstrap timed out after ${elapsedSeconds}s without session ID (${stage})`
+      : `Planner session bootstrap timed out (${stage})`;
+
+    if (retryCount <= maxRestarts) {
+      console.warn(`[ralph:worker:${this.repo}] Planner bootstrap timeout; resetting to queued: ${reason}`);
+      await this.queue.updateTaskStatus(task, "queued", {
+        "session-id": "",
+        "planner-bootstrap-retries": String(nextRetryCount),
+        "blocked-source": "stall",
+        "blocked-reason": reason,
+        "blocked-details": timeout?.context ? `Context: ${timeout.context}` : "",
+        "blocked-at": new Date().toISOString(),
+        "blocked-checked-at": new Date().toISOString(),
+        "daemon-id": "",
+        "heartbeat-at": "",
+        "worker-id": "",
+        "repo-slot": "",
+      });
+
+      return {
+        taskName: task.name,
+        repo: this.repo,
+        outcome: "failed",
+        escalationReason: reason,
+      };
+    }
+
+    console.log(`[ralph:worker:${this.repo}] Planner bootstrap timeout repeated; escalating: ${reason}`);
+    const escalationFields: Record<string, string> = {
+      "planner-bootstrap-retries": String(nextRetryCount),
+    };
+
+    const wasEscalated = task.status === "escalated";
+    const escalated = await this.queue.updateTaskStatus(task, "escalated", escalationFields);
+    if (escalated) {
+      applyTaskPatch(task, "escalated", escalationFields);
+    }
+
+    const details = [
+      timeout?.context ? `Context: ${timeout.context}` : null,
+      task["run-log-path"]?.trim() ? `Run log: ${task["run-log-path"]?.trim()}` : null,
+    ]
+      .filter(Boolean)
+      .join("\n");
+
+    const githubCommentUrl = await this.writeEscalationWriteback(task, {
+      reason,
+      details: details || undefined,
+      escalationType: "other",
+    });
+    await this.notify.notifyEscalation({
+      taskName: task.name,
+      taskFileName: task._name,
+      taskPath: task._path,
+      issue: task.issue,
+      repo: this.repo,
+      scope: task.scope,
+      priority: task.priority,
+      reason,
+      escalationType: "other",
+      githubCommentUrl: githubCommentUrl ?? undefined,
+      planOutput: result.output,
+    });
+
+    if (escalated && !wasEscalated) {
+      await this.recordEscalatedRunNote(task, {
+        reason,
+        details: result.output,
+      });
+    }
+
+    return {
+      taskName: task.name,
+      repo: this.repo,
+      outcome: "escalated",
+      escalationReason: reason,
     };
   }
 


### PR DESCRIPTION
## Summary
- Add a planner bootstrap timeout path that fails runs which never emit a session id, with explicit diagnostics in session results.
- Recover deterministically by re-queuing and clearing ownership/session fields, then escalate after bounded retries for repeated planner bootstrap timeouts.
- Harden GitHub status-label reconciliation to bypass debounce when labels are already drifted (queued + in-progress), and add regression tests for bootstrap timeout, startup reset, and drift healing.

## Testing
- bun test src/__tests__/session-stall.test.ts src/__tests__/github-queue-update-task-status.test.ts src/__tests__/session-persistence.test.ts

Closes #690