### PR TITLE
fix: support daemon startup auth probe for GitHub App tokens

### DIFF
--- a/src/__tests__/daemon-gh-auth-probe.test.ts
+++ b/src/__tests__/daemon-gh-auth-probe.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test";
+
+import type { RalphConfig } from "../config";
+import { resolveDaemonAuthProbe, validateDaemonGhAuth } from "../github/daemon-auth-probe";
+
+type RunnerProcess = {
+  cwd: (path: string) => RunnerProcess;
+  quiet: () => Promise<{ stdout: string }>;
+};
+
+function toCommand(strings: TemplateStringsArray, values: unknown[]): string {
+  let out = strings[0] ?? "";
+  for (let i = 0; i < values.length; i += 1) {
+    out += String(values[i] ?? "");
+    out += strings[i + 1] ?? "";
+  }
+  return out.trim();
+}
+
+function createConfig(overrides?: Partial<RalphConfig>): RalphConfig {
+  return {
+    repos: [],
+    maxWorkers: 1,
+    batchSize: 10,
+    pollInterval: 30_000,
+    doneReconcileIntervalMs: 300_000,
+    labelReconcileIntervalMs: 300_000,
+    ownershipTtlMs: 60_000,
+    owner: "3mdistal",
+    devDir: "/tmp",
+    ...overrides,
+  } as RalphConfig;
+}
+
+function createRunnerFrom(
+  exec: (command: string) => Promise<{ stdout: string }>
+): (repo: string) => (strings: TemplateStringsArray, ...values: unknown[]) => RunnerProcess {
+  return () => {
+    return (strings: TemplateStringsArray, ...values: unknown[]): RunnerProcess => {
+      const command = toCommand(strings, values);
+      const processLike: RunnerProcess = {
+        cwd: () => processLike,
+        quiet: async () => exec(command),
+      };
+      return processLike;
+    };
+  };
+}
+
+describe("daemon github auth probe", () => {
+  test("uses repo-scoped probe when prod githubApp auth is configured", async () => {
+    const config = createConfig({
+      githubApp: {
+        appId: 123,
+        installationId: 456,
+        privateKeyPath: "/tmp/key.pem",
+      },
+    });
+    const commands: string[] = [];
+
+    await validateDaemonGhAuth({
+      config,
+      probeRepo: "3mdistal/ralph",
+      createRunner: createRunnerFrom(async (command) => {
+        commands.push(command);
+        return { stdout: "" };
+      }),
+    });
+
+    expect(resolveDaemonAuthProbe(config, "3mdistal/ralph")).toEqual({
+      kind: "repo",
+      command: "gh api repos/3mdistal/ralph",
+    });
+    expect(commands).toEqual(["gh api repos/3mdistal/ralph"]);
+  });
+
+  test("invalid app auth still fails with clear diagnostics", async () => {
+    const config = createConfig({
+      githubApp: {
+        appId: 123,
+        installationId: 456,
+        privateKeyPath: "/tmp/key.pem",
+      },
+    });
+
+    let errorMessage = "";
+    try {
+      await validateDaemonGhAuth({
+        config,
+        probeRepo: "3mdistal/ralph",
+        createRunner: createRunnerFrom(async (command) => {
+          const error: any = new Error("Resource not accessible by integration (HTTP 403)");
+          error.ghCommand = command;
+          error.stderr = "HTTP 403";
+          throw error;
+        }),
+      });
+    } catch (error: any) {
+      errorMessage = String(error?.message ?? "");
+    }
+
+    expect(errorMessage).toContain("[ralph] GitHub auth validation failed for gh CLI (daemon mode).");
+    expect(errorMessage).toContain("Command: gh api repos/3mdistal/ralph");
+    expect(errorMessage).toContain("Message: Resource not accessible by integration (HTTP 403)");
+    expect(errorMessage).toContain("stderr: HTTP 403");
+  });
+
+  test("keeps /user probe for non-app token flow", async () => {
+    const config = createConfig({ githubApp: undefined });
+    const commands: string[] = [];
+
+    await validateDaemonGhAuth({
+      config,
+      probeRepo: "3mdistal/ralph",
+      createRunner: createRunnerFrom(async (command) => {
+        commands.push(command);
+        return { stdout: "" };
+      }),
+    });
+
+    expect(resolveDaemonAuthProbe(config, "3mdistal/ralph")).toEqual({
+      kind: "user",
+      command: "gh api /user",
+    });
+    expect(commands).toEqual(["gh api /user"]);
+  });
+});

--- a/src/github/daemon-auth-probe.ts
+++ b/src/github/daemon-auth-probe.ts
@@ -1,0 +1,71 @@
+import type { RalphConfig } from "../config";
+
+import { createGhRunner } from "./gh-runner";
+
+type GhCommandResult = { stdout: Uint8Array | string | { toString(): string } };
+
+type GhProcess = {
+  cwd: (path: string) => GhProcess;
+  quiet: () => Promise<GhCommandResult>;
+};
+
+type GhRunner = (strings: TemplateStringsArray, ...values: unknown[]) => GhProcess;
+
+type GhRunnerFactory = (repo: string) => GhRunner;
+
+type DaemonAuthProbe =
+  | { kind: "repo"; command: string }
+  | { kind: "user"; command: "gh api /user" };
+
+function hasProdGitHubApp(config: RalphConfig): boolean {
+  const app = config.githubApp;
+  if (!app) return false;
+  const keyPath = typeof app.privateKeyPath === "string" ? app.privateKeyPath.trim() : "";
+  return keyPath.length > 0;
+}
+
+export function resolveDaemonAuthProbe(config: RalphConfig, probeRepo: string): DaemonAuthProbe {
+  if (hasProdGitHubApp(config)) {
+    return { kind: "repo", command: `gh api repos/${probeRepo}` };
+  }
+  return { kind: "user", command: "gh api /user" };
+}
+
+function formatDaemonGhAuthValidationError(error: any): string {
+  const command = String(error?.ghCommand ?? error?.command ?? "").trim();
+  const message = String(error?.message ?? "").trim();
+  const stderr = typeof error?.stderr?.toString === "function" ? String(error.stderr.toString()).trim() : "";
+
+  return [
+    "[ralph] GitHub auth validation failed for gh CLI (daemon mode).",
+    command ? `Command: ${command}` : "",
+    message ? `Message: ${message}` : "",
+    stderr ? `stderr: ${stderr.slice(0, 1600)}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export async function validateDaemonGhAuth(params: {
+  config: RalphConfig;
+  probeRepo: string;
+  createRunner?: GhRunnerFactory;
+}): Promise<void> {
+  const createRunner =
+    params.createRunner ??
+    ((repo: string) => {
+      return createGhRunner({ repo, mode: "read" });
+    });
+  const probe = resolveDaemonAuthProbe(params.config, params.probeRepo);
+  const ghRead = createRunner(params.probeRepo);
+
+  try {
+    if (probe.kind === "repo") {
+      await ghRead`gh api repos/${params.probeRepo}`.quiet();
+      return;
+    }
+    await ghRead`gh api /user`.quiet();
+  } catch (error: any) {
+    throw new Error(formatDaemonGhAuthValidationError(error));
+  }
+}


### PR DESCRIPTION
## Summary
- switch daemon startup auth validation to a mode-aware probe in prod: use `gh api repos/<repo>` when `githubApp` auth is configured
- keep `/user` auth validation for non-app token flows
- add focused tests for app-auth success path, app-auth failure diagnostics, and non-app compatibility

## Testing
- `bun test src/__tests__/daemon-gh-auth-probe.test.ts`

Fixes #693