### PR TITLE
fix(github): gc orphaned task op-state and report status orphans

### DIFF
--- a/src/__tests__/github-queue-orphan-gc.test.ts
+++ b/src/__tests__/github-queue-orphan-gc.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, mkdir, rm, writeFile } from "fs/promises";
+import { dirname, join } from "path";
+import { tmpdir } from "os";
+
+import { acquireGlobalTestLock } from "./helpers/test-lock";
+import { getRalphConfigJsonPath } from "../paths";
+
+let homeDir: string;
+let priorHome: string | undefined;
+let priorStateDb: string | undefined;
+let releaseLock: (() => void) | null = null;
+
+async function writeJson(path: string, obj: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(obj, null, 2), "utf8");
+}
+
+describe("GitHub queue orphan op-state GC", () => {
+  beforeEach(async () => {
+    priorHome = process.env.HOME;
+    priorStateDb = process.env.RALPH_STATE_DB_PATH;
+    releaseLock = await acquireGlobalTestLock();
+    homeDir = await mkdtemp(join(tmpdir(), "ralph-home-"));
+    process.env.HOME = homeDir;
+    process.env.RALPH_STATE_DB_PATH = join(homeDir, "state.sqlite");
+
+    const cfgMod = await import("../config");
+    cfgMod.__resetConfigForTests();
+
+    const stateMod = await import("../state");
+    stateMod.closeStateDbForTests();
+  });
+
+  afterEach(async () => {
+    const stateMod = await import("../state");
+    stateMod.closeStateDbForTests();
+
+    const cfgMod = await import("../config");
+    cfgMod.__resetConfigForTests();
+
+    process.env.HOME = priorHome;
+    if (priorStateDb === undefined) delete process.env.RALPH_STATE_DB_PATH;
+    else process.env.RALPH_STATE_DB_PATH = priorStateDb;
+    await rm(homeDir, { recursive: true, force: true });
+    releaseLock?.();
+    releaseLock = null;
+  });
+
+  test("clears stale no-label orphan op-state and prunes candidates", async () => {
+    await writeJson(getRalphConfigJsonPath(), {
+      queueBackend: "github",
+      ownershipTtlMs: 60_000,
+      repos: [{ name: "3mdistal/ralph", path: "/tmp/ralph", botBranch: "bot/integration" }],
+    });
+
+    const cfgMod = await import("../config");
+    cfgMod.__resetConfigForTests();
+
+    const stateMod = await import("../state");
+    stateMod.closeStateDbForTests();
+    stateMod.initStateDb();
+
+    const now = new Date("2026-02-11T12:00:00.000Z");
+    const heartbeat = new Date(now.getTime() - 120_000).toISOString();
+
+    stateMod.recordIssueSnapshot({
+      repo: "3mdistal/ralph",
+      issue: "3mdistal/ralph#210",
+      state: "OPEN",
+      at: now.toISOString(),
+    });
+    stateMod.recordIssueLabelsSnapshot({
+      repo: "3mdistal/ralph",
+      issue: "3mdistal/ralph#210",
+      labels: [],
+      at: now.toISOString(),
+    });
+    stateMod.recordTaskSnapshot({
+      repo: "3mdistal/ralph",
+      issue: "3mdistal/ralph#210",
+      taskPath: "github:3mdistal/ralph#210",
+      status: "blocked",
+      sessionId: "sess-210",
+      worktreePath: "/home/test/.ralph/worktrees/3mdistal-ralph/slot-1/210/task-a",
+      workerId: "worker-1",
+      repoSlot: "1",
+      daemonId: "daemon-1",
+      heartbeatAt: heartbeat,
+      at: now.toISOString(),
+    });
+
+    const prunes: string[] = [];
+    const queueMod = await import("../github-queue/io");
+    const driver = queueMod.createGitHubQueueDriver({
+      now: () => now,
+      pruneWorktree: async ({ worktreePath }: { worktreePath: string }) => {
+        prunes.push(worktreePath);
+        return {
+          attempted: true,
+          pruned: true,
+          gitRemoved: true,
+          safety: { safe: true, reason: "ok", normalizedPath: worktreePath },
+        };
+      },
+      io: {
+        ensureWorkflowLabels: async () => ({ ok: true, created: [], updated: [] }),
+        listIssueLabels: async () => [],
+        fetchIssue: async () => null,
+        reopenIssue: async () => {},
+        addIssueLabel: async () => {},
+        addIssueLabels: async () => {},
+        removeIssueLabel: async () => ({ removed: true }),
+        mutateIssueLabels: async () => true,
+      },
+    });
+
+    await driver.getTasksByStatus("queued");
+
+    expect(prunes.length).toBeGreaterThan(0);
+    const opState = stateMod.getTaskOpStateByPath("3mdistal/ralph", "github:3mdistal/ralph#210");
+    expect(opState?.sessionId ?? null).toBeNull();
+    expect(opState?.worktreePath ?? null).toBeNull();
+    expect(opState?.daemonId ?? null).toBeNull();
+    expect(opState?.heartbeatAt ?? null).toBeNull();
+    expect(opState?.releasedReason ?? null).toBe("orphan:no-ralph-labels");
+  });
+
+  test("keeps fresh no-label orphan op-state", async () => {
+    await writeJson(getRalphConfigJsonPath(), {
+      queueBackend: "github",
+      ownershipTtlMs: 60_000,
+      repos: [{ name: "3mdistal/ralph", path: "/tmp/ralph", botBranch: "bot/integration" }],
+    });
+
+    const cfgMod = await import("../config");
+    cfgMod.__resetConfigForTests();
+
+    const stateMod = await import("../state");
+    stateMod.closeStateDbForTests();
+    stateMod.initStateDb();
+
+    const now = new Date("2026-02-11T12:00:00.000Z");
+
+    stateMod.recordIssueSnapshot({ repo: "3mdistal/ralph", issue: "3mdistal/ralph#211", state: "OPEN", at: now.toISOString() });
+    stateMod.recordIssueLabelsSnapshot({
+      repo: "3mdistal/ralph",
+      issue: "3mdistal/ralph#211",
+      labels: [],
+      at: now.toISOString(),
+    });
+    stateMod.recordTaskSnapshot({
+      repo: "3mdistal/ralph",
+      issue: "3mdistal/ralph#211",
+      taskPath: "github:3mdistal/ralph#211",
+      status: "in-progress",
+      sessionId: "sess-211",
+      worktreePath: "/home/test/.ralph/worktrees/3mdistal-ralph/slot-0/211/task-a",
+      daemonId: "daemon-1",
+      heartbeatAt: now.toISOString(),
+      at: now.toISOString(),
+    });
+
+    const queueMod = await import("../github-queue/io");
+    const driver = queueMod.createGitHubQueueDriver({
+      now: () => now,
+      io: {
+        ensureWorkflowLabels: async () => ({ ok: true, created: [], updated: [] }),
+        listIssueLabels: async () => [],
+        fetchIssue: async () => null,
+        reopenIssue: async () => {},
+        addIssueLabel: async () => {},
+        addIssueLabels: async () => {},
+        removeIssueLabel: async () => ({ removed: true }),
+        mutateIssueLabels: async () => true,
+      },
+    });
+
+    await driver.getTasksByStatus("queued");
+
+    const opState = stateMod.getTaskOpStateByPath("3mdistal/ralph", "github:3mdistal/ralph#211");
+    expect(opState?.sessionId ?? null).toBe("sess-211");
+    expect(opState?.worktreePath ?? null).toContain("/211/");
+  });
+});

--- a/src/__tests__/state-orphan-op-state.test.ts
+++ b/src/__tests__/state-orphan-op-state.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+
+import { acquireGlobalTestLock } from "./helpers/test-lock";
+
+let homeDir: string;
+let priorHome: string | undefined;
+let priorStateDb: string | undefined;
+let releaseLock: (() => void) | null = null;
+
+describe("state orphan op-state helpers", () => {
+  beforeEach(async () => {
+    priorHome = process.env.HOME;
+    priorStateDb = process.env.RALPH_STATE_DB_PATH;
+    releaseLock = await acquireGlobalTestLock();
+
+    homeDir = await mkdtemp(join(tmpdir(), "ralph-home-"));
+    process.env.HOME = homeDir;
+    process.env.RALPH_STATE_DB_PATH = join(homeDir, "state.sqlite");
+
+    const stateMod = await import("../state");
+    stateMod.closeStateDbForTests();
+    stateMod.initStateDb();
+  });
+
+  afterEach(async () => {
+    const stateMod = await import("../state");
+    stateMod.closeStateDbForTests();
+
+    process.env.HOME = priorHome;
+    if (priorStateDb === undefined) delete process.env.RALPH_STATE_DB_PATH;
+    else process.env.RALPH_STATE_DB_PATH = priorStateDb;
+
+    await rm(homeDir, { recursive: true, force: true });
+    releaseLock?.();
+    releaseLock = null;
+  });
+
+  test("lists orphaned task op-state and clears with CAS guard", async () => {
+    const stateMod = await import("../state");
+    const now = "2026-02-11T10:00:00.000Z";
+
+    stateMod.recordIssueSnapshot({
+      repo: "3mdistal/ralph",
+      issue: "3mdistal/ralph#210",
+      title: "orphan",
+      state: "OPEN",
+      at: now,
+    });
+    stateMod.recordIssueLabelsSnapshot({
+      repo: "3mdistal/ralph",
+      issue: "3mdistal/ralph#210",
+      labels: [],
+      at: now,
+    });
+    stateMod.recordTaskSnapshot({
+      repo: "3mdistal/ralph",
+      issue: "3mdistal/ralph#210",
+      taskPath: "github:3mdistal/ralph#210",
+      status: "blocked",
+      sessionId: "sess-1",
+      worktreePath: "/tmp/worktrees/slot-1/210/task",
+      workerId: "worker-1",
+      repoSlot: "1",
+      daemonId: "daemon-1",
+      heartbeatAt: "2026-02-11T09:50:00.000Z",
+      at: now,
+    });
+
+    const orphans = stateMod.listOrphanedTasksWithOpState("3mdistal/ralph");
+    expect(orphans).toHaveLength(1);
+    expect(orphans[0]?.orphanReason).toBe("no-ralph-labels");
+
+    const race = stateMod.clearTaskOpState({
+      repo: "3mdistal/ralph",
+      taskPath: "github:3mdistal/ralph#210",
+      expectedDaemonId: "daemon-other",
+      expectedHeartbeatAt: "2026-02-11T09:50:00.000Z",
+      releasedReason: "orphan:no-ralph-labels",
+    });
+    expect(race).toEqual({ cleared: false, raceSkipped: true });
+
+    const cleared = stateMod.clearTaskOpState({
+      repo: "3mdistal/ralph",
+      taskPath: "github:3mdistal/ralph#210",
+      expectedDaemonId: "daemon-1",
+      expectedHeartbeatAt: "2026-02-11T09:50:00.000Z",
+      releasedReason: "orphan:no-ralph-labels",
+    });
+    expect(cleared).toEqual({ cleared: true, raceSkipped: false });
+
+    const opState = stateMod.getTaskOpStateByPath("3mdistal/ralph", "github:3mdistal/ralph#210");
+    expect(opState?.sessionId ?? null).toBeNull();
+    expect(opState?.worktreePath ?? null).toBeNull();
+    expect(opState?.daemonId ?? null).toBeNull();
+    expect(opState?.heartbeatAt ?? null).toBeNull();
+  });
+});

--- a/src/__tests__/worktree-prune.test.ts
+++ b/src/__tests__/worktree-prune.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+
+import { computeTaskWorktreeCandidates, evaluateWorktreePruneSafety, pruneManagedWorktreeBestEffort } from "../worktree-prune";
+
+describe("worktree prune safety", () => {
+  const managedRoot = "/home/test/.ralph/worktrees";
+  const repoPath = "/home/test/Developer/ralph";
+  const devDir = "/home/test/Developer";
+
+  test("allows managed slot layout path", () => {
+    const safety = evaluateWorktreePruneSafety({
+      worktreePath: "/home/test/.ralph/worktrees/3mdistal-ralph/slot-2/210/task-a",
+      managedRoot,
+      repoPath,
+      devDir,
+    });
+    expect(safety.safe).toBe(true);
+    expect(safety.reason).toBe("ok");
+  });
+
+  test("denies outside managed root and repo root", () => {
+    const outside = evaluateWorktreePruneSafety({
+      worktreePath: "/tmp/random",
+      managedRoot,
+      repoPath,
+      devDir,
+    });
+    expect(outside.safe).toBe(false);
+    expect(outside.reason).toBe("outside-managed-root");
+
+    const repoRoot = evaluateWorktreePruneSafety({
+      worktreePath: repoPath,
+      managedRoot,
+      repoPath,
+      devDir,
+    });
+    expect(repoRoot.safe).toBe(false);
+    expect(repoRoot.reason).toBe("outside-managed-root");
+  });
+
+  test("denies invalid layout under managed root", () => {
+    const safety = evaluateWorktreePruneSafety({
+      worktreePath: "/home/test/.ralph/worktrees/3mdistal-ralph/not-a-slot",
+      managedRoot,
+      repoPath,
+      devDir,
+    });
+    expect(safety.safe).toBe(false);
+    expect(safety.reason).toBe("invalid-layout");
+  });
+
+  test("unsafe prune exits without attempting deletion", async () => {
+    const result = await pruneManagedWorktreeBestEffort({
+      repoPath,
+      worktreePath: "/tmp/unsafe",
+      managedRoot,
+      devDir,
+    });
+    expect(result.attempted).toBe(false);
+    expect(result.pruned).toBe(false);
+  });
+
+  test("computes candidate worktree paths from recorded and slot", () => {
+    const candidates = computeTaskWorktreeCandidates({
+      repo: "3mdistal/ralph",
+      issueNumber: 210,
+      taskPath: "github:3mdistal/ralph#210",
+      repoSlot: "2",
+      recordedWorktreePath: "/home/test/.ralph/worktrees/3mdistal-ralph/slot-2/210/task-a",
+    });
+    expect(candidates.length).toBeGreaterThanOrEqual(1);
+    expect(candidates[0]).toContain(".ralph/worktrees");
+  });
+});

--- a/src/worktree-prune.ts
+++ b/src/worktree-prune.ts
@@ -1,0 +1,145 @@
+import { $ } from "bun";
+import { existsSync } from "fs";
+import { rm } from "fs/promises";
+import { relative, resolve } from "path";
+
+import { isLegacyWorktreePath, isPathUnderDir } from "./git-worktree";
+import { buildWorktreePath } from "./worktree-paths";
+
+export type WorktreePruneSafety = {
+  safe: boolean;
+  reason: "ok" | "missing-path" | "outside-managed-root" | "repo-root" | "legacy-worktree" | "invalid-layout";
+  normalizedPath: string | null;
+};
+
+export type WorktreePruneResult = {
+  attempted: boolean;
+  pruned: boolean;
+  safety: WorktreePruneSafety;
+  gitRemoved: boolean;
+  error?: string;
+};
+
+function isValidManagedLayout(path: string, managedRoot: string): boolean {
+  const rel = relative(resolve(managedRoot), resolve(path));
+  if (!rel || rel.startsWith("..")) return false;
+  const segments = rel.split(/[\\/]+/).filter(Boolean);
+  if (segments.length < 4) return false;
+  return /^slot-\d+$/.test(segments[1] ?? "");
+}
+
+export function evaluateWorktreePruneSafety(params: {
+  worktreePath?: string | null;
+  managedRoot: string;
+  repoPath: string;
+  devDir: string;
+}): WorktreePruneSafety {
+  const rawPath = params.worktreePath?.trim() ?? "";
+  if (!rawPath) {
+    return { safe: false, reason: "missing-path", normalizedPath: null };
+  }
+
+  const normalizedPath = resolve(rawPath);
+  const managedRoot = resolve(params.managedRoot);
+  const repoPath = resolve(params.repoPath);
+
+  if (!isPathUnderDir(normalizedPath, managedRoot)) {
+    return { safe: false, reason: "outside-managed-root", normalizedPath };
+  }
+  if (normalizedPath === repoPath) {
+    return { safe: false, reason: "repo-root", normalizedPath };
+  }
+  if (isLegacyWorktreePath(normalizedPath, { devDir: params.devDir, managedRoot })) {
+    return { safe: false, reason: "legacy-worktree", normalizedPath };
+  }
+  if (!isValidManagedLayout(normalizedPath, managedRoot)) {
+    return { safe: false, reason: "invalid-layout", normalizedPath };
+  }
+
+  return { safe: true, reason: "ok", normalizedPath };
+}
+
+export async function pruneManagedWorktreeBestEffort(params: {
+  repoPath: string;
+  worktreePath?: string | null;
+  managedRoot: string;
+  devDir: string;
+}): Promise<WorktreePruneResult> {
+  const safety = evaluateWorktreePruneSafety(params);
+  if (!safety.safe || !safety.normalizedPath) {
+    return { attempted: false, pruned: false, safety, gitRemoved: false };
+  }
+
+  const targetPath = safety.normalizedPath;
+  let gitRemoved = false;
+  let lastError = "";
+
+  try {
+    await $`git worktree remove --force ${targetPath}`.cwd(params.repoPath).quiet();
+    gitRemoved = true;
+  } catch (error: any) {
+    lastError = error?.message ?? String(error);
+  }
+
+  try {
+    if (existsSync(targetPath)) {
+      await rm(targetPath, { recursive: true, force: true });
+    }
+    return { attempted: true, pruned: true, safety, gitRemoved, ...(lastError ? { error: lastError } : {}) };
+  } catch (error: any) {
+    const message = error?.message ?? String(error);
+    return {
+      attempted: true,
+      pruned: gitRemoved,
+      safety,
+      gitRemoved,
+      error: lastError ? `${lastError}; ${message}` : message,
+    };
+  }
+}
+
+function parseRepoSlot(slot: string | null | undefined): number | null {
+  if (typeof slot !== "string") return null;
+  const trimmed = slot.trim();
+  if (!trimmed) return null;
+  const parsed = Number(trimmed);
+  if (!Number.isInteger(parsed) || parsed < 0) return null;
+  return parsed;
+}
+
+export function computeTaskWorktreeCandidates(params: {
+  repo: string;
+  issueNumber: number | null;
+  taskPath: string;
+  repoSlot: string | null | undefined;
+  recordedWorktreePath?: string | null;
+}): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  const add = (value: string | null | undefined) => {
+    const trimmed = value?.trim();
+    if (!trimmed) return;
+    const normalized = resolve(trimmed);
+    if (seen.has(normalized)) return;
+    seen.add(normalized);
+    out.push(normalized);
+  };
+
+  add(params.recordedWorktreePath);
+
+  if (typeof params.issueNumber === "number" && Number.isFinite(params.issueNumber)) {
+    const parsedSlot = parseRepoSlot(params.repoSlot);
+    if (typeof parsedSlot === "number") {
+      add(
+        buildWorktreePath({
+          repo: params.repo,
+          issueNumber: String(params.issueNumber),
+          taskKey: params.taskPath,
+          repoSlot: parsedSlot,
+        })
+      );
+    }
+  }
+
+  return out;
+}


### PR DESCRIPTION
## Summary
- add an orphan GC sweep that detects closed/no-ralph-label issues with lingering op-state, clears local task ownership fields, and best-effort prunes managed worktrees
- wire orphan diagnostics into /snapshot output so tasks with op-state but no GitHub queue membership are visible
- cover GC, state listing, and worktree prune behavior with focused tests

## Testing
- bun test src/__tests__/github-queue-orphan-gc.test.ts src/__tests__/state-orphan-op-state.test.ts src/__tests__/worktree-prune.test.ts

Closes #672