### PR TITLE
feat(gates): add readonly query CLI with stable output

### DIFF
--- a/docs/product/deterministic-gates.md
+++ b/docs/product/deterministic-gates.md
@@ -104,6 +104,22 @@ Ralph exposes a minimal query surface for the latest persisted gate state:
 
 This reads from `~/.ralph/state.sqlite` and returns the bounded/redacted artifacts stored with the gate records.
 
+JSON contract (`--json`):
+
+- Versioned envelope: `version` (current `2`), `repo`, `issueNumber`, `runId`, `gates`, `artifacts`, `error`.
+- `gates[]` contains latest per-gate state in workflow order (`preflight`, `plan_review`, `product_review`, `devex_review`, `ci`, `pr_evidence`) with:
+  - `name`, `status`, `createdAt`, `updatedAt`, `command`, `skipReason`, `reason`, `url`, `prNumber`, `prUrl`.
+- `artifacts[]` contains bounded artifact records with:
+  - `id`, `gate`, `kind`, `createdAt`, `updatedAt`, `truncated`, `content`.
+- `error` is `null` on success. On durable-state failure, `error` is populated with `code`, `message`, and (when available) schema compatibility fields.
+- Compatibility rule: JSON evolution is additive-only (new optional fields may be added; existing fields and meanings are stable).
+
+Exit behavior:
+
+- `0`: command executed successfully (including "no gate state found").
+- `1`: invalid CLI usage.
+- `2`: durable-state unreadable/degraded for gates query; text mode writes reason to stderr, JSON mode emits a stable envelope with `error` populated.
+
 ## Gate 1: Local Preflight (Fast, Deterministic)
 
 Default: required.

--- a/src/__tests__/gates-command.test.ts
+++ b/src/__tests__/gates-command.test.ts
@@ -2,12 +2,14 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtemp, rm } from "fs/promises";
 import { join } from "path";
 import { tmpdir } from "os";
+import { Database } from "bun:sqlite";
 
-import { buildGatesJsonOutput } from "../commands/gates";
+import { buildGatesJsonOutput, runGatesCommand } from "../commands/gates";
 import {
   closeStateDbForTests,
   createRalphRun,
   ensureRalphRunGateRows,
+  getDurableStateSchemaWindow,
   getLatestRunGateStateForIssue,
   initStateDb,
   recordRalphRunGateArtifact,
@@ -18,6 +20,43 @@ import { acquireGlobalTestLock } from "./helpers/test-lock";
 let homeDir: string;
 let priorStateDbPath: string | undefined;
 let releaseLock: (() => void) | null = null;
+
+type CapturedRun = {
+  logs: string[];
+  errors: string[];
+  thrown: unknown;
+};
+
+async function runGates(args: string[]): Promise<CapturedRun> {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const priorLog = console.log;
+  const priorError = console.error;
+  const priorExit = process.exit;
+  let thrown: unknown = null;
+
+  console.log = (...line: any[]) => {
+    logs.push(line.join(" "));
+  };
+  console.error = (...line: any[]) => {
+    errors.push(line.join(" "));
+  };
+  (process.exit as any) = (code?: number) => {
+    throw new Error(`exit:${code ?? 0}`);
+  };
+
+  try {
+    await runGatesCommand({ args });
+  } catch (error) {
+    thrown = error;
+  } finally {
+    console.log = priorLog;
+    console.error = priorError;
+    process.exit = priorExit;
+  }
+
+  return { logs, errors, thrown };
+}
 
 describe("gates command output", () => {
   beforeEach(async () => {
@@ -82,18 +121,10 @@ describe("gates command output", () => {
       runId,
       gates: [
         {
-          name: "ci",
-          status: "fail",
-          command: null,
-          skipReason: null,
-          reason: null,
-          url: "https://github.com/3mdistal/ralph/actions/runs/1200",
-          prNumber: 240,
-          prUrl: "https://github.com/3mdistal/ralph/pull/240",
-        },
-        {
-          name: "devex_review",
+          name: "preflight",
           status: "pending",
+          createdAt: "2026-01-20T13:00:01.000Z",
+          updatedAt: "2026-01-20T13:00:01.000Z",
           command: null,
           skipReason: null,
           reason: null,
@@ -104,26 +135,8 @@ describe("gates command output", () => {
         {
           name: "plan_review",
           status: "pending",
-          command: null,
-          skipReason: null,
-          reason: null,
-          url: null,
-          prNumber: null,
-          prUrl: null,
-        },
-        {
-          name: "pr_evidence",
-          status: "pending",
-          command: null,
-          skipReason: null,
-          reason: null,
-          url: null,
-          prNumber: null,
-          prUrl: null,
-        },
-        {
-          name: "preflight",
-          status: "pending",
+          createdAt: "2026-01-20T13:00:01.000Z",
+          updatedAt: "2026-01-20T13:00:01.000Z",
           command: null,
           skipReason: null,
           reason: null,
@@ -134,6 +147,44 @@ describe("gates command output", () => {
         {
           name: "product_review",
           status: "pending",
+          createdAt: "2026-01-20T13:00:01.000Z",
+          updatedAt: "2026-01-20T13:00:01.000Z",
+          command: null,
+          skipReason: null,
+          reason: null,
+          url: null,
+          prNumber: null,
+          prUrl: null,
+        },
+        {
+          name: "devex_review",
+          status: "pending",
+          createdAt: "2026-01-20T13:00:01.000Z",
+          updatedAt: "2026-01-20T13:00:01.000Z",
+          command: null,
+          skipReason: null,
+          reason: null,
+          url: null,
+          prNumber: null,
+          prUrl: null,
+        },
+        {
+          name: "ci",
+          status: "fail",
+          createdAt: "2026-01-20T13:00:01.000Z",
+          updatedAt: "2026-01-20T13:00:02.000Z",
+          command: null,
+          skipReason: null,
+          reason: null,
+          url: "https://github.com/3mdistal/ralph/actions/runs/1200",
+          prNumber: 240,
+          prUrl: "https://github.com/3mdistal/ralph/pull/240",
+        },
+        {
+          name: "pr_evidence",
+          status: "pending",
+          createdAt: "2026-01-20T13:00:01.000Z",
+          updatedAt: "2026-01-20T13:00:01.000Z",
           command: null,
           skipReason: null,
           reason: null,
@@ -144,12 +195,103 @@ describe("gates command output", () => {
       ],
       artifacts: [
         {
+          id: 1,
           gate: "ci",
           kind: "failure_excerpt",
+          createdAt: "2026-01-20T13:00:03.000Z",
+          updatedAt: "2026-01-20T13:00:03.000Z",
           truncated: false,
           content: "short log",
         },
       ],
+      error: null,
     });
+  });
+
+  test("uses read-only path when durable state is forward-newer but readable", async () => {
+    initStateDb();
+    const runId = createRalphRun({
+      repo: "3mdistal/ralph",
+      issue: "3mdistal/ralph#240",
+      taskPath: "github:3mdistal/ralph#240",
+      attemptKind: "process",
+      startedAt: "2026-01-20T13:00:00.000Z",
+    });
+    ensureRalphRunGateRows({ runId, at: "2026-01-20T13:00:01.000Z" });
+    upsertRalphRunGateResult({
+      runId,
+      gate: "preflight",
+      status: "pass",
+      reason: "ok",
+      at: "2026-01-20T13:00:02.000Z",
+    });
+
+    closeStateDbForTests();
+    const stateDbPath = process.env.RALPH_STATE_DB_PATH as string;
+    const db = new Database(stateDbPath);
+    try {
+      const window = getDurableStateSchemaWindow();
+      db.exec("CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)");
+      db.exec("DELETE FROM meta WHERE key = 'schema_version'");
+      db.exec(`INSERT INTO meta(key, value) VALUES ('schema_version', '${window.maxWritableSchema + 1}')`);
+    } finally {
+      db.close();
+    }
+
+    const { logs, thrown } = await runGates(["gates", "3mdistal/ralph", "240", "--json"]);
+    expect(String((thrown as any)?.message ?? "")).toContain("exit:0");
+    const parsed = JSON.parse(logs.find((line) => line.trim().startsWith("{")) ?? "{}") as Record<string, any>;
+    expect(parsed.error).toBeNull();
+    expect(parsed.runId).toBe(runId);
+    expect(parsed.gates[0]?.name).toBe("preflight");
+    expect(parsed.gates[0]?.status).toBe("pass");
+  });
+
+  test("emits stable JSON error payload for forward-incompatible durable state", async () => {
+    const stateDbPath = process.env.RALPH_STATE_DB_PATH as string;
+    const db = new Database(stateDbPath);
+    try {
+      db.exec("CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)");
+      db.exec("DELETE FROM meta WHERE key = 'schema_version'");
+      db.exec("INSERT INTO meta(key, value) VALUES ('schema_version', '999')");
+    } finally {
+      db.close();
+    }
+
+    const { logs, thrown } = await runGates(["gates", "3mdistal/ralph", "240", "--json"]);
+    expect(String((thrown as any)?.message ?? "")).toContain("exit:2");
+    const parsed = JSON.parse(logs.find((line) => line.trim().startsWith("{")) ?? "{}") as Record<string, any>;
+    expect(parsed.version).toBe(2);
+    expect(parsed.repo).toBe("3mdistal/ralph");
+    expect(parsed.issueNumber).toBe(240);
+    expect(parsed.runId).toBeNull();
+    expect(parsed.gates).toEqual([]);
+    expect(parsed.artifacts).toEqual([]);
+    expect(parsed.error?.code).toBe("forward_incompatible");
+    expect(typeof parsed.error?.message).toBe("string");
+  });
+
+  test("text output keeps artifact excerpts bounded", async () => {
+    initStateDb();
+    const runId = createRalphRun({
+      repo: "3mdistal/ralph",
+      issue: "3mdistal/ralph#240",
+      taskPath: "github:3mdistal/ralph#240",
+      attemptKind: "process",
+      startedAt: "2026-01-20T13:00:00.000Z",
+    });
+    ensureRalphRunGateRows({ runId, at: "2026-01-20T13:00:01.000Z" });
+    recordRalphRunGateArtifact({
+      runId,
+      gate: "ci",
+      kind: "failure_excerpt",
+      content: "line-1\nline-2\nline-3\nline-4",
+      at: "2026-01-20T13:00:03.000Z",
+    });
+
+    const { logs, thrown } = await runGates(["gates", "3mdistal/ralph", "240"]);
+    expect(String((thrown as any)?.message ?? "")).toContain("exit:0");
+    expect(logs.some((line) => line.includes("Artifacts:"))).toBeTrue();
+    expect(logs.some((line) => line.includes("... (1 more lines)"))).toBeTrue();
   });
 });

--- a/src/commands/gates.ts
+++ b/src/commands/gates.ts
@@ -1,6 +1,10 @@
 import {
+  classifyDurableStateInitError,
+  getLatestRunGateStateForIssueReadonly,
   getLatestRunGateStateForIssue,
   initStateDb,
+  isDurableStateInitError,
+  probeDurableState,
   type GateArtifactKind,
   type GateName,
   type GateStatus,
@@ -16,6 +20,8 @@ function parseIssueNumber(raw: string | undefined): number | null {
 type GateResultProjection = {
   name: GateName;
   status: GateStatus;
+  createdAt: string;
+  updatedAt: string;
   command: string | null;
   skipReason: string | null;
   reason: string | null;
@@ -25,10 +31,21 @@ type GateResultProjection = {
 };
 
 type GateArtifactProjection = {
+  id: number;
   gate: GateName;
   kind: GateArtifactKind;
+  createdAt: string;
+  updatedAt: string;
   truncated: boolean;
   content: string;
+};
+
+type GatesErrorOutput = {
+  code: string;
+  message: string;
+  schemaVersion?: number;
+  supportedRange?: string;
+  writableRange?: string;
 };
 
 export type GatesJsonOutput = {
@@ -38,16 +55,55 @@ export type GatesJsonOutput = {
   runId: string | null;
   gates: GateResultProjection[];
   artifacts: GateArtifactProjection[];
+  error: GatesErrorOutput | null;
 };
+
+const GATE_ORDER: GateName[] = ["preflight", "plan_review", "product_review", "devex_review", "ci", "pr_evidence"];
+
+const MAX_EXCERPT_LINES = 3;
+const MAX_EXCERPT_CHARS = 160;
+
+function gateOrder(gate: GateName): number {
+  const idx = GATE_ORDER.indexOf(gate);
+  return idx >= 0 ? idx : Number.MAX_SAFE_INTEGER;
+}
+
+function buildArtifactExcerpt(content: string): string[] {
+  const lines = content.split("\n");
+  const excerpt = lines.slice(0, MAX_EXCERPT_LINES).map((line) => {
+    if (line.length <= MAX_EXCERPT_CHARS) return line;
+    return `${line.slice(0, MAX_EXCERPT_CHARS - 3)}...`;
+  });
+  const hiddenLineCount = lines.length - excerpt.length;
+  if (hiddenLineCount > 0) {
+    excerpt.push(`... (${hiddenLineCount} more lines)`);
+  }
+  return excerpt;
+}
+
+function buildErrorOutput(error: ReturnType<typeof classifyDurableStateInitError>): GatesErrorOutput {
+  return {
+    code: error.code,
+    message: error.message,
+    schemaVersion: error.schemaVersion,
+    supportedRange: error.supportedRange,
+    writableRange: error.writableRange,
+  };
+}
 
 export function buildGatesJsonOutput(params: {
   repo: string;
   issueNumber: number;
   state: RalphRunGateState | null;
+  error?: GatesErrorOutput | null;
 }): GatesJsonOutput {
   const runId = params.state?.results[0]?.runId ?? null;
-  const results = params.state?.results ?? [];
-  const artifacts = params.state?.artifacts ?? [];
+  const results = [...(params.state?.results ?? [])].sort((left, right) => {
+    const orderDelta = gateOrder(left.gate) - gateOrder(right.gate);
+    if (orderDelta !== 0) return orderDelta;
+    return left.gate.localeCompare(right.gate);
+  });
+  const artifacts = [...(params.state?.artifacts ?? [])].sort((left, right) => left.id - right.id);
 
   return {
     version: 2,
@@ -57,6 +113,8 @@ export function buildGatesJsonOutput(params: {
     gates: results.map((result) => ({
       name: result.gate,
       status: result.status,
+      createdAt: result.createdAt,
+      updatedAt: result.updatedAt,
       command: result.command,
       skipReason: result.skipReason,
       reason: result.reason,
@@ -65,11 +123,15 @@ export function buildGatesJsonOutput(params: {
       prUrl: result.prUrl,
     })),
     artifacts: artifacts.map((artifact) => ({
+      id: artifact.id,
       gate: artifact.gate,
       kind: artifact.kind,
+      createdAt: artifact.createdAt,
+      updatedAt: artifact.updatedAt,
       truncated: artifact.truncated,
       content: artifact.content,
     })),
+    error: params.error ?? null,
   };
 }
 
@@ -85,8 +147,47 @@ export async function runGatesCommand(opts: { args: string[] }): Promise<void> {
     return;
   }
 
-  initStateDb();
-  const state = getLatestRunGateStateForIssue({ repo, issueNumber });
+  const emitDurableStateError = (error: ReturnType<typeof classifyDurableStateInitError>) => {
+    if (json) {
+      console.log(
+        JSON.stringify(
+          buildGatesJsonOutput({
+            repo,
+            issueNumber,
+            state: null,
+            error: buildErrorOutput(error),
+          }),
+          null,
+          2
+        )
+      );
+    } else {
+      console.error(`Unable to read durable state (${error.code}): ${error.message}`);
+    }
+    process.exit(2);
+  };
+
+  const probe = probeDurableState();
+  if (!probe.ok) {
+    emitDurableStateError(probe);
+    return;
+  }
+
+  let state: RalphRunGateState | null;
+  if (probe.canWriteState === false) {
+    state = getLatestRunGateStateForIssueReadonly({ repo, issueNumber });
+  } else {
+    try {
+      initStateDb();
+      state = getLatestRunGateStateForIssue({ repo, issueNumber });
+    } catch (error) {
+      if (!isDurableStateInitError(error)) {
+        throw error;
+      }
+      emitDurableStateError(classifyDurableStateInitError(error));
+      return;
+    }
+  }
 
   if (json) {
     console.log(JSON.stringify(buildGatesJsonOutput({ repo, issueNumber, state }), null, 2));
@@ -103,8 +204,14 @@ export async function runGatesCommand(opts: { args: string[] }): Promise<void> {
   const runId = state.results[0]?.runId ?? "(unknown)";
   console.log(`Gate state for ${repo}#${issueNumber} (run ${runId}):`);
 
-  for (const result of state.results) {
-    console.log(`- ${result.gate}: ${result.status}`);
+  const orderedResults = [...state.results].sort((left, right) => {
+    const orderDelta = gateOrder(left.gate) - gateOrder(right.gate);
+    if (orderDelta !== 0) return orderDelta;
+    return left.gate.localeCompare(right.gate);
+  });
+
+  for (const result of orderedResults) {
+    console.log(`- ${result.gate}: ${result.status} (updated ${result.updatedAt})`);
     if (result.command) console.log(`  command: ${result.command}`);
     if (result.skipReason) console.log(`  skip reason: ${result.skipReason}`);
     if (result.reason) console.log(`  reason: ${result.reason}`);
@@ -115,12 +222,17 @@ export async function runGatesCommand(opts: { args: string[] }): Promise<void> {
 
   if (state.artifacts.length > 0) {
     console.log("Artifacts:");
-    for (const artifact of state.artifacts) {
-      console.log(`- ${artifact.gate}/${artifact.kind}${artifact.truncated ? " (truncated)" : ""}`);
-      const lines = artifact.content.split("\n");
-      for (const line of lines) {
+    const orderedArtifacts = [...state.artifacts].sort((left, right) => left.id - right.id);
+    for (const artifact of orderedArtifacts) {
+      console.log(
+        `- #${artifact.id} ${artifact.gate}/${artifact.kind}${artifact.truncated ? " (truncated)" : ""} ` +
+          `[${artifact.updatedAt}]`
+      );
+      for (const line of buildArtifactExcerpt(artifact.content)) {
         console.log(`  ${line}`);
       }
     }
   }
+
+  process.exit(0);
 }


### PR DESCRIPTION
## Summary
- Restore the existing implementation for #728 by adding a readonly `gates` query path and stable output contract.
- Persist/query gate records through SQLite-backed state primitives and wire command output for deterministic orchestration checks.
- Extend tests and deterministic-gates docs to cover the new query behavior and output guarantees.

## Testing
- `bun test src/__tests__/gates-command.test.ts`
- `bun test src/__tests__/state-sqlite.test.ts -t "gate"`

Closes #728
Related to #743