### PR TITLE
test: prevent daemon-record tests from poisoning canonical control state

### DIFF
--- a/src/__tests__/daemon-record.test.ts
+++ b/src/__tests__/daemon-record.test.ts
@@ -36,6 +36,7 @@ describe("daemon record", () => {
     const base = mkdtempSync(join(tmpdir(), "ralph-daemon-"));
     tempDirs.push(base);
     process.env.XDG_STATE_HOME = base;
+    process.env.HOME = base;
 
     writeDaemonRecord({
       version: 1,


### PR DESCRIPTION
## Summary
- Set `HOME` alongside `XDG_STATE_HOME` in the base daemon-record write/read test to keep canonical daemon-record writes inside the test temp directory.
- Prevents accidental writes to `~/.ralph/control/daemon-registry.json` from test runs that use `d_test` fixtures.

## Testing
- `bun test src/__tests__/daemon-record.test.ts src/__tests__/daemon-discovery.test.ts`

Related to #746