### PR TITLE
fix: recover PR branch from detached worktree head

### DIFF
--- a/src/worker/repo-worker.ts
+++ b/src/worker/repo-worker.ts
@@ -2416,6 +2416,43 @@ export class RepoWorker {
     return "UNKNOWN";
   }
 
+  private normalizeRecoveryBranchIssueSegment(issueNumber: string): string {
+    const normalized = String(issueNumber ?? "").trim().replace(/[^0-9A-Za-z._-]+/g, "-");
+    return normalized.length > 0 ? normalized : "unknown";
+  }
+
+  private async materializeDetachedHeadRecoveryBranch(params: {
+    worktreePath: string;
+    issueNumber: string;
+  }): Promise<{ branch: string | null; diagnostics: string[] }> {
+    const diagnostics: string[] = [];
+    const issueSegment = this.normalizeRecoveryBranchIssueSegment(params.issueNumber);
+
+    let headSha = "";
+    try {
+      const headOut = await $`git rev-parse --short=12 HEAD`.cwd(params.worktreePath).quiet();
+      headSha = headOut.stdout.toString().trim();
+    } catch (error: any) {
+      diagnostics.push(`- Unable to resolve HEAD SHA for detached branch recovery: ${error?.message ?? String(error)}`);
+      return { branch: null, diagnostics };
+    }
+
+    if (!headSha) {
+      diagnostics.push("- Unable to resolve HEAD SHA for detached branch recovery");
+      return { branch: null, diagnostics };
+    }
+
+    const recoveryBranch = `ralph/recovery-${issueSegment}-${headSha}`;
+    try {
+      await $`git checkout -B ${recoveryBranch} HEAD`.cwd(params.worktreePath).quiet();
+      diagnostics.push(`- Materialized recovery branch from detached HEAD: ${recoveryBranch}`);
+      return { branch: recoveryBranch, diagnostics };
+    } catch (error: any) {
+      diagnostics.push(`- Failed to materialize recovery branch ${recoveryBranch}: ${error?.message ?? String(error)}`);
+      return { branch: null, diagnostics };
+    }
+  }
+
   private async tryEnsurePrFromWorktree(params: {
     task: AgentTask;
     issueNumber: string;
@@ -2471,14 +2508,22 @@ export class RepoWorker {
       return { prUrl: null, diagnostics: diagnostics.join("\n"), causeCode: "NO_WORKTREE_BRANCH" };
     }
 
-    const branch = stripHeadsRef(candidate.branch);
+    let branch = stripHeadsRef(candidate.branch);
     diagnostics.push(`- Worktree: ${candidate.worktreePath}`);
     diagnostics.push(`- Branch: ${branch ?? "(unknown)"}`);
 
     if (!branch || candidate.detached) {
-      diagnostics.push("- Cannot auto-create PR: detached HEAD or unknown branch");
-      diagnostics.push(formatPrEvidenceCauseCodeLine("NO_WORKTREE_BRANCH"));
-      return { prUrl: null, diagnostics: diagnostics.join("\n"), causeCode: "NO_WORKTREE_BRANCH" };
+      const recovered = await this.materializeDetachedHeadRecoveryBranch({
+        worktreePath: candidate.worktreePath,
+        issueNumber,
+      });
+      diagnostics.push(...recovered.diagnostics);
+      branch = recovered.branch;
+      if (!branch) {
+        diagnostics.push("- Cannot auto-create PR: detached HEAD or unknown branch");
+        diagnostics.push(formatPrEvidenceCauseCodeLine("NO_WORKTREE_BRANCH"));
+        return { prUrl: null, diagnostics: diagnostics.join("\n"), causeCode: "NO_WORKTREE_BRANCH" };
+      }
     }
 
     try {


### PR DESCRIPTION
## Summary
- Harden PR recovery to materialize a deterministic local branch when the selected issue worktree is on detached HEAD.
- Continue normal push/PR creation from that branch instead of immediately failing with `PR_EVIDENCE_CAUSE_CODE=NO_WORKTREE_BRANCH`.
- Add a regression test ensuring detached worktree recovery attempts branch materialization before emitting NO_WORKTREE_BRANCH.

## Testing
- `bun test src/__tests__/pr-recovery-terminal-skip.test.ts`

Related to #743
Related to #745