### PR TITLE
feat(status): backport blocked-as-queued projection + schema22 support

### DIFF
--- a/src/__tests__/blocked-comment.test.ts
+++ b/src/__tests__/blocked-comment.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildBlockedCommentBody, extractDependencyRefs, parseBlockedCommentState } from "../github/blocked-comment";
+
+describe("blocked comment", () => {
+  test("builds and parses v1 state payload", () => {
+    const body = buildBlockedCommentBody({
+      marker: "<!-- ralph-blocked:v1 id=abc123 -->",
+      issueNumber: 745,
+      state: {
+        version: 1,
+        kind: "deps",
+        blocked: true,
+        reason: "blocked by 3mdistal/ralph#11",
+        deps: [{ repo: "3mdistal/ralph", issueNumber: 11 }],
+        blockedAt: "2026-02-14T21:08:07.311Z",
+        updatedAt: "2026-02-14T21:08:08.000Z",
+      },
+    });
+
+    const parsed = parseBlockedCommentState(body);
+    expect(parsed).toBeTruthy();
+    expect(parsed?.blocked).toBe(true);
+    expect(parsed?.deps).toEqual([{ repo: "3mdistal/ralph", issueNumber: 11 }]);
+  });
+
+  test("returns null for malformed state payload", () => {
+    const parsed = parseBlockedCommentState("<!-- ralph-blocked:state={not-json} -->");
+    expect(parsed).toBeNull();
+  });
+
+  test("extracts dependency refs from reason text", () => {
+    const refs = extractDependencyRefs("blocked by #11 and 3mdistal/ralph#42", "3mdistal/ralph");
+    expect(refs).toEqual([
+      { repo: "3mdistal/ralph", issueNumber: 11 },
+      { repo: "3mdistal/ralph", issueNumber: 42 },
+    ]);
+  });
+});

--- a/src/__tests__/github-queue-core.test.ts
+++ b/src/__tests__/github-queue-core.test.ts
@@ -126,9 +126,11 @@ describe("github queue core", () => {
     expect(delta).toEqual({ add: ["ralph:status:in-progress"], remove: ["ralph:status:queued"] });
   });
 
-  test("statusToRalphLabelDelta maps blocked to in-progress from queued", () => {
-    const delta = statusToRalphLabelDelta("blocked", ["ralph:status:queued"]);
-    expect(delta).toEqual({ add: ["ralph:status:in-progress"], remove: ["ralph:status:queued"] });
+  test("statusToRalphLabelDelta maps deps-blocked to queued", () => {
+    const delta = statusToRalphLabelDelta("blocked", ["ralph:status:in-progress"], {
+      opState: { status: "blocked", blockedSource: "deps" },
+    });
+    expect(delta).toEqual({ add: ["ralph:status:queued"], remove: ["ralph:status:in-progress"] });
   });
 
   test("statusToRalphLabelDelta preserves in-progress when blocked", () => {
@@ -136,8 +138,10 @@ describe("github queue core", () => {
     expect(delta).toEqual({ add: [], remove: [] });
   });
 
-  test("statusToRalphLabelDelta removes other status labels when blocked", () => {
-    const delta = statusToRalphLabelDelta("blocked", ["ralph:status:queued", "ralph:status:in-progress"]);
+  test("statusToRalphLabelDelta removes other status labels when non-deps blocked", () => {
+    const delta = statusToRalphLabelDelta("blocked", ["ralph:status:queued", "ralph:status:in-progress"], {
+      opState: { status: "blocked", blockedSource: "runtime-error" },
+    });
     expect(delta).toEqual({ add: ["ralph:status:in-progress"], remove: ["ralph:status:queued"] });
   });
 
@@ -164,16 +168,13 @@ describe("github queue core", () => {
     expect(delta).toEqual({ add: ["ralph:status:in-progress"], remove: [] });
   });
 
-  test("statusToRalphLabelDelta supports blocked to queued round-trip", () => {
-    const blockedDelta = statusToRalphLabelDelta("blocked", ["ralph:status:queued"]);
+  test("statusToRalphLabelDelta keeps queued for deps-blocked", () => {
+    const blockedDelta = statusToRalphLabelDelta("blocked", ["ralph:status:queued"], {
+      opState: { status: "blocked", blockedSource: "deps" },
+    });
     const blockedLabels = applyDelta(["ralph:status:queued"], blockedDelta);
-    expect(blockedLabels).toContain("ralph:status:in-progress");
-    expect(blockedLabels).not.toContain("ralph:status:queued");
-
-    const queuedDelta = statusToRalphLabelDelta("queued", blockedLabels);
-    const queuedLabels = applyDelta(blockedLabels, queuedDelta);
-    expect(queuedLabels).toContain("ralph:status:queued");
-    expect(queuedLabels).not.toContain("ralph:status:in-progress");
+    expect(blockedLabels).toContain("ralph:status:queued");
+    expect(blockedLabels).not.toContain("ralph:status:in-progress");
   });
 
   test("statusToRalphLabelDelta maps escalated to escalated", () => {

--- a/src/__tests__/queue-parity-audit.test.ts
+++ b/src/__tests__/queue-parity-audit.test.ts
@@ -25,7 +25,37 @@ describe("queue parity audit", () => {
     });
 
     expect(report.ghQueuedLocalBlocked).toBe(1);
+    expect(report.localDepsBlockedGhInProgress).toBe(0);
+    expect(report.localDepsBlockedMissingMeta).toBe(0);
     expect(report.sampleGhQueuedLocalBlocked).toEqual(["3mdistal/ralph#101"]);
+  });
+
+  test("counts deps-blocked projected as in-progress and missing meta label", () => {
+    const report = computeQueueParityAudit({
+      repo: "3mdistal/ralph",
+      issues: [
+        {
+          repo: "3mdistal/ralph",
+          number: 301,
+          state: "OPEN",
+          labels: ["ralph:status:in-progress"],
+        },
+      ],
+      opStates: [
+        {
+          repo: "3mdistal/ralph",
+          issueNumber: 301,
+          taskPath: "github:3mdistal/ralph#301",
+          status: "blocked",
+          blockedSource: "deps",
+        },
+      ],
+    });
+
+    expect(report.localDepsBlockedGhInProgress).toBe(1);
+    expect(report.localDepsBlockedMissingMeta).toBe(1);
+    expect(report.sampleLocalDepsBlockedGhInProgress).toEqual(["3mdistal/ralph#301"]);
+    expect(report.sampleLocalDepsBlockedMissingMeta).toEqual(["3mdistal/ralph#301"]);
   });
 
   test("counts multi-status and missing-status issues", () => {

--- a/src/__tests__/state-sqlite.test.ts
+++ b/src/__tests__/state-sqlite.test.ts
@@ -332,7 +332,7 @@ describe("State SQLite (~/.ralph/state.sqlite)", () => {
         integrity_check_result?: string;
       };
       expect(backupRow.from_schema_version).toBe(7);
-      expect(backupRow.to_schema_version).toBe(21);
+      expect(backupRow.to_schema_version).toBe(22);
       expect(backupRow.integrity_check_result).toBe("ok");
       expect(backupRow.backup_size_bytes).toBeGreaterThan(0);
       expect(backupRow.backup_sha256).toMatch(/^[a-f0-9]{64}$/);
@@ -341,13 +341,13 @@ describe("State SQLite (~/.ralph/state.sqlite)", () => {
         "SELECT from_schema_version, to_schema_version, completed_at FROM state_migration_attempts ORDER BY id DESC LIMIT 1"
       ).get() as { from_schema_version?: number; to_schema_version?: number; completed_at?: string | null };
       expect(attemptRow.from_schema_version).toBe(7);
-      expect(attemptRow.to_schema_version).toBe(21);
+      expect(attemptRow.to_schema_version).toBe(22);
       expect(attemptRow.completed_at).toBeString();
 
       const completionCheckpoint = verify.query(
-        "SELECT checkpoint FROM state_migration_ledger WHERE checkpoint = 'schema-v21-complete' LIMIT 1"
+        "SELECT checkpoint FROM state_migration_ledger WHERE checkpoint = 'schema-v22-complete' LIMIT 1"
       ).get() as { checkpoint?: string } | undefined;
-      expect(completionCheckpoint?.checkpoint).toBe("schema-v21-complete");
+      expect(completionCheckpoint?.checkpoint).toBe("schema-v22-complete");
     } finally {
       verify.close();
     }
@@ -531,7 +531,7 @@ describe("State SQLite (~/.ralph/state.sqlite)", () => {
       const meta = migrated
         .query("SELECT value FROM meta WHERE key = 'schema_version'")
         .get() as { value?: string };
-      expect(meta.value).toBe("21");
+      expect(meta.value).toBe("22");
 
       const issueColumns = migrated.query("PRAGMA table_info(issues)").all() as Array<{ name: string }>;
       const issueColumnNames = issueColumns.map((column) => column.name);
@@ -651,7 +651,7 @@ describe("State SQLite (~/.ralph/state.sqlite)", () => {
       const meta = migrated
         .query("SELECT value FROM meta WHERE key = 'schema_version'")
         .get() as { value?: string };
-      expect(meta.value).toBe("21");
+      expect(meta.value).toBe("22");
 
       const columns = migrated.query("PRAGMA table_info(tasks)").all() as Array<{ name: string }>;
       const columnNames = columns.map((column) => column.name);
@@ -1139,7 +1139,7 @@ describe("State SQLite (~/.ralph/state.sqlite)", () => {
     const migrated = new Database(dbPath);
     try {
       const meta = migrated.query("SELECT value FROM meta WHERE key = 'schema_version'").get() as { value?: string };
-      expect(meta.value).toBe("21");
+      expect(meta.value).toBe("22");
 
       migrated
         .query(
@@ -1254,7 +1254,7 @@ describe("State SQLite (~/.ralph/state.sqlite)", () => {
     const migrated = new Database(dbPath);
     try {
       const meta = migrated.query("SELECT value FROM meta WHERE key = 'schema_version'").get() as { value?: string };
-      expect(meta.value).toBe("21");
+      expect(meta.value).toBe("22");
 
       const row = migrated
         .query("SELECT reason FROM ralph_run_gate_results WHERE run_id = 'run_v18' AND gate = 'ci'")
@@ -1376,7 +1376,7 @@ describe("State SQLite (~/.ralph/state.sqlite)", () => {
     const migrated = new Database(dbPath);
     try {
       const meta = migrated.query("SELECT value FROM meta WHERE key = 'schema_version'").get() as { value?: string };
-      expect(meta.value).toBe("21");
+      expect(meta.value).toBe("22");
 
       const backfilled = migrated
         .query("SELECT status FROM ralph_run_gate_results WHERE run_id = 'run_v20' AND gate = 'plan_review'")
@@ -1654,7 +1654,7 @@ describe("State SQLite (~/.ralph/state.sqlite)", () => {
 
     try {
       const meta = db.query("SELECT value FROM meta WHERE key = 'schema_version'").get() as { value?: string };
-      expect(meta.value).toBe("21");
+      expect(meta.value).toBe("22");
 
       const repoCount = db.query("SELECT COUNT(*) as n FROM repos").get() as { n: number };
       expect(repoCount.n).toBe(1);

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -59,6 +59,8 @@ function buildQueueParitySnapshot(repos: string[]) {
   const perRepo = repos.map((repo) => auditQueueParityForRepo(repo));
   return {
     ghQueuedLocalBlocked: perRepo.reduce((sum, repo) => sum + repo.ghQueuedLocalBlocked, 0),
+    localDepsBlockedGhInProgress: perRepo.reduce((sum, repo) => sum + repo.localDepsBlockedGhInProgress, 0),
+    localDepsBlockedMissingMeta: perRepo.reduce((sum, repo) => sum + repo.localDepsBlockedMissingMeta, 0),
     multiStatusLabels: perRepo.reduce((sum, repo) => sum + repo.multiStatusLabels, 0),
     missingStatusWithOpState: perRepo.reduce((sum, repo) => sum + repo.missingStatusWithOpState, 0),
     repos: perRepo,
@@ -782,7 +784,7 @@ export async function runStatusCommand(opts: { args: string[]; drain: StatusDrai
     console.log(`Queue diagnostics: ${base.queueState.diagnostics}`);
   }
   console.log(
-    `Queue parity: ghQueued/localBlocked=${base.parity.ghQueuedLocalBlocked} multiStatus=${base.parity.multiStatusLabels} missingStatus=${base.parity.missingStatusWithOpState}`
+    `Queue parity: ghQueued/localBlocked=${base.parity.ghQueuedLocalBlocked} depsBlockedGhInProgress=${base.parity.localDepsBlockedGhInProgress} depsBlockedMissingMeta=${base.parity.localDepsBlockedMissingMeta} multiStatus=${base.parity.multiStatusLabels} missingStatus=${base.parity.missingStatusWithOpState}`
   );
   if (base.parity.ghQueuedLocalBlocked > 0) {
     const samples = base.parity.repos.flatMap((repo) => repo.sampleGhQueuedLocalBlocked).slice(0, 5);

--- a/src/github-labels.ts
+++ b/src/github-labels.ts
@@ -36,6 +36,7 @@ export const RALPH_LABEL_STATUS_ESCALATED = "ralph:status:escalated";
 export const RALPH_LABEL_STATUS_IN_BOT = "ralph:status:in-bot";
 export const RALPH_LABEL_STATUS_DONE = "ralph:status:done";
 export const RALPH_LABEL_STATUS_STOPPED = "ralph:status:stopped";
+export const RALPH_LABEL_META_BLOCKED = "ralph:meta:blocked";
 
 export const RALPH_LABEL_CMD_QUEUE = `${RALPH_CMD_LABEL_PREFIX}queue`;
 export const RALPH_LABEL_CMD_PAUSE = `${RALPH_CMD_LABEL_PREFIX}pause`;
@@ -51,6 +52,9 @@ export const RALPH_WORKFLOW_LABELS: readonly LabelSpec[] = [
   { name: RALPH_LABEL_STATUS_IN_BOT, color: "0E8A16", description: "Task PR merged to bot/integration" },
   { name: RALPH_LABEL_STATUS_DONE, color: "1A7F37", description: "Task merged to default branch" },
   { name: RALPH_LABEL_STATUS_STOPPED, color: "B60205", description: "Operator cancelled; do not proceed" },
+
+  // Metadata (Ralph-managed, non-status)
+  { name: RALPH_LABEL_META_BLOCKED, color: "C2E0C6", description: "Dependency-blocked; see Ralph blocked status comment" },
 
   // Commands (operator-owned; ephemeral)
   { name: RALPH_LABEL_CMD_QUEUE, color: "C5DEF5", description: "Command: enqueue / re-enqueue" },

--- a/src/github-queue/core.ts
+++ b/src/github-queue/core.ts
@@ -13,14 +13,24 @@ import {
 
 export type LabelOp = { action: "add" | "remove"; label: string };
 
-const BLOCKED_PUBLIC_STATUS_LABEL = RALPH_LABEL_STATUS_IN_PROGRESS;
+export function isDependencyBlocked(opState?: Pick<TaskOpState, "status" | "blockedSource"> | null): boolean {
+  if (!opState) return false;
+  const status = opState.status?.trim() ?? "";
+  if (status !== "blocked") return false;
+  const blockedSource = opState.blockedSource?.trim() ?? "";
+  return blockedSource === "deps";
+}
+
+function resolveBlockedPublicStatusLabel(opState?: Pick<TaskOpState, "status" | "blockedSource"> | null): string {
+  return isDependencyBlocked(opState) ? RALPH_LABEL_STATUS_QUEUED : RALPH_LABEL_STATUS_IN_PROGRESS;
+}
 
 const RALPH_STATUS_LABELS: Record<QueueTaskStatus, string | null> = {
   queued: RALPH_LABEL_STATUS_QUEUED,
   "in-progress": RALPH_LABEL_STATUS_IN_PROGRESS,
   "waiting-on-pr": RALPH_LABEL_STATUS_IN_PROGRESS,
   paused: RALPH_LABEL_STATUS_PAUSED,
-  blocked: BLOCKED_PUBLIC_STATUS_LABEL,
+  blocked: RALPH_LABEL_STATUS_IN_PROGRESS,
   escalated: RALPH_LABEL_STATUS_ESCALATED,
   done: RALPH_LABEL_STATUS_DONE,
   starting: RALPH_LABEL_STATUS_IN_PROGRESS,
@@ -72,12 +82,19 @@ function resolveFallbackStatusLabel(labels: string[]): string | null {
   return null;
 }
 
-export function statusToRalphLabelDelta(status: QueueTaskStatus, currentLabels: string[]): {
+export function statusToRalphLabelDelta(
+  status: QueueTaskStatus,
+  currentLabels: string[],
+  opts?: { opState?: Pick<TaskOpState, "status" | "blockedSource"> | null }
+): {
   add: string[];
   remove: string[];
 } {
   const labelSet = new Set(currentLabels);
-  const target = RALPH_STATUS_LABELS[status] ?? resolveFallbackStatusLabel(currentLabels) ?? RALPH_LABEL_STATUS_QUEUED;
+  const target =
+    status === "blocked"
+      ? resolveBlockedPublicStatusLabel(opts?.opState)
+      : (RALPH_STATUS_LABELS[status] ?? resolveFallbackStatusLabel(currentLabels) ?? RALPH_LABEL_STATUS_QUEUED);
   const add: string[] = [];
   if (!labelSet.has(target)) add.push(target);
   const remove = KNOWN_RALPH_STATUS_LABELS.filter((label) => label !== target && labelSet.has(label));
@@ -264,5 +281,10 @@ export function deriveTaskView(params: {
     "repo-slot": params.opState?.repoSlot ?? undefined,
     "daemon-id": params.opState?.daemonId ?? undefined,
     "heartbeat-at": params.opState?.heartbeatAt ?? undefined,
+    "blocked-source": (params.opState?.blockedSource as AgentTask["blocked-source"] | null) ?? undefined,
+    "blocked-reason": params.opState?.blockedReason ?? undefined,
+    "blocked-at": params.opState?.blockedAt ?? undefined,
+    "blocked-details": params.opState?.blockedDetails ?? undefined,
+    "blocked-checked-at": params.opState?.blockedCheckedAt ?? undefined,
   };
 }

--- a/src/github/blocked-comment.ts
+++ b/src/github/blocked-comment.ts
@@ -1,0 +1,182 @@
+import { deleteIdempotencyKey, getIdempotencyPayload, initStateDb, recordIdempotencyKey, upsertIdempotencyKey } from "../state";
+import { parseIssueRef } from "./issue-ref";
+import { splitRepoFullName, type GitHubClient } from "./client";
+
+export type BlockedCommentState = {
+  version: 1;
+  kind: "deps";
+  blocked: boolean;
+  reason: string | null;
+  deps: Array<{ repo: string; issueNumber: number }>;
+  blockedAt: string | null;
+  updatedAt: string;
+};
+
+type BlockedCommentRecord = {
+  id: number;
+  body: string;
+  updatedAt?: string;
+  htmlUrl?: string;
+};
+
+const MARKER_REGEX = /<!--\s*ralph-blocked:v1\s+id=([a-z0-9]+)\s*-->/i;
+const STATE_REGEX = /<!--\s*ralph-blocked:state=([^>]+)\s*-->/i;
+const FNV_OFFSET = 2166136261;
+const FNV_PRIME = 16777619;
+
+function hashFNV1a(input: string): string {
+  let hash = FNV_OFFSET;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, FNV_PRIME) >>> 0;
+  }
+  return hash.toString(16).padStart(8, "0");
+}
+
+function buildMarkerId(repo: string, issueNumber: number): string {
+  const base = `${repo}|${issueNumber}|blocked`;
+  return `${hashFNV1a(base)}${hashFNV1a(base.split("").reverse().join(""))}`.slice(0, 12);
+}
+
+function bodyHash(body: string): string {
+  return hashFNV1a(body.replace(/\r\n/g, "\n").trimEnd() + "\n");
+}
+
+function parsePayloadBodyHash(payload: string | null): string | null {
+  if (!payload) return null;
+  try {
+    const parsed = JSON.parse(payload) as { bodyHash?: unknown };
+    return typeof parsed.bodyHash === "string" ? parsed.bodyHash : null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseBlockedCommentState(body: string): BlockedCommentState | null {
+  const match = body.match(STATE_REGEX);
+  if (!match?.[1]) return null;
+  try {
+    const parsed = JSON.parse(match[1]) as BlockedCommentState;
+    if (!parsed || parsed.version !== 1 || parsed.kind !== "deps") return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function extractDependencyRefs(text: string, baseRepo: string): Array<{ repo: string; issueNumber: number }> {
+  const found = new Map<string, { repo: string; issueNumber: number }>();
+  const re = /(?:[\w.-]+\/[\w.-]+)?#\d+/g;
+  for (const match of text.matchAll(re)) {
+    const raw = match[0]?.trim() ?? "";
+    if (!raw) continue;
+    const ref = parseIssueRef(raw, baseRepo);
+    if (!ref) continue;
+    found.set(`${ref.repo}#${ref.number}`, { repo: ref.repo, issueNumber: ref.number });
+  }
+  return [...found.values()];
+}
+
+export function buildBlockedCommentBody(params: {
+  marker: string;
+  state: BlockedCommentState;
+  issueNumber: number;
+}): string {
+  const stateLine = `<!-- ralph-blocked:state=${JSON.stringify(params.state)} -->`;
+  const human = params.state.blocked
+    ? [
+        `Blocked on dependencies for #${params.issueNumber}.`,
+        "",
+        `Reason: ${params.state.reason ?? "(none)"}`,
+        `Blocked at: ${params.state.blockedAt ?? "unknown"}`,
+      ]
+    : [`Dependencies unblocked for #${params.issueNumber}.`];
+  return [params.marker, stateLine, "", ...human].join("\n");
+}
+
+async function findBlockedComment(params: {
+  github: GitHubClient;
+  repo: string;
+  issueNumber: number;
+  markerId: string;
+  marker: string;
+  limit?: number;
+}): Promise<BlockedCommentRecord | null> {
+  const { owner, name } = splitRepoFullName(params.repo);
+  const limit = Math.min(Math.max(1, params.limit ?? 50), 100);
+  const response = await params.github.request<Array<{ id?: number | null; body?: string | null; updated_at?: string | null; html_url?: string | null }>>(
+    `/repos/${owner}/${name}/issues/${params.issueNumber}/comments?per_page=${limit}&sort=created&direction=desc`
+  );
+  for (const comment of response.data ?? []) {
+    const body = comment?.body ?? "";
+    const match = body.match(MARKER_REGEX);
+    const marker = match?.[1] ?? "";
+    if (marker.toLowerCase() !== params.markerId.toLowerCase() && !body.includes(params.marker)) continue;
+    const id = typeof comment?.id === "number" ? comment.id : Number(comment?.id ?? 0);
+    if (!id) continue;
+    return {
+      id,
+      body,
+      updatedAt: comment?.updated_at ?? undefined,
+      htmlUrl: comment?.html_url ?? undefined,
+    };
+  }
+  return null;
+}
+
+export async function upsertBlockedComment(params: {
+  github: GitHubClient;
+  repo: string;
+  issueNumber: number;
+  state: BlockedCommentState;
+  limit?: number;
+}): Promise<{ updated: boolean; url: string | null }> {
+  initStateDb();
+  const markerId = buildMarkerId(params.repo, params.issueNumber);
+  const marker = `<!-- ralph-blocked:v1 id=${markerId} -->`;
+  const body = buildBlockedCommentBody({ marker, state: params.state, issueNumber: params.issueNumber });
+  const expectedHash = bodyHash(body);
+  const idempotencyKey = `gh-blocked-comment:${params.repo}#${params.issueNumber}:${markerId}`;
+  const priorHash = parsePayloadBodyHash(getIdempotencyPayload(idempotencyKey));
+
+  const existing = await findBlockedComment({
+    github: params.github,
+    repo: params.repo,
+    issueNumber: params.issueNumber,
+    markerId,
+    marker,
+    limit: params.limit,
+  });
+
+  if (existing) {
+    if (bodyHash(existing.body) === expectedHash) {
+      upsertIdempotencyKey({ key: idempotencyKey, scope: "gh-blocked-comment", payloadJson: JSON.stringify({ bodyHash: expectedHash }) });
+      return { updated: false, url: existing.htmlUrl ?? null };
+    }
+    const { owner, name } = splitRepoFullName(params.repo);
+    const updated = await params.github.request<{ html_url?: string | null }>(
+      `/repos/${owner}/${name}/issues/comments/${existing.id}`,
+      { method: "PATCH", body: { body } }
+    );
+    upsertIdempotencyKey({ key: idempotencyKey, scope: "gh-blocked-comment", payloadJson: JSON.stringify({ bodyHash: expectedHash }) });
+    return { updated: true, url: updated.data?.html_url ?? existing.htmlUrl ?? null };
+  }
+
+  const claimed = recordIdempotencyKey({ key: idempotencyKey, scope: "gh-blocked-comment", payloadJson: JSON.stringify({ bodyHash: expectedHash }) });
+  if (!claimed && priorHash === expectedHash) {
+    return { updated: false, url: null };
+  }
+
+  try {
+    const { owner, name } = splitRepoFullName(params.repo);
+    const created = await params.github.request<{ html_url?: string | null }>(
+      `/repos/${owner}/${name}/issues/${params.issueNumber}/comments`,
+      { method: "POST", body: { body } }
+    );
+    upsertIdempotencyKey({ key: idempotencyKey, scope: "gh-blocked-comment", payloadJson: JSON.stringify({ bodyHash: expectedHash }) });
+    return { updated: true, url: created.data?.html_url ?? null };
+  } catch (error) {
+    deleteIdempotencyKey(idempotencyKey);
+    throw error;
+  }
+}

--- a/src/state.ts
+++ b/src/state.ts
@@ -17,7 +17,7 @@ import {
   type DurableStateSchemaWindow,
 } from "./durable-state-capability";
 
-const SCHEMA_VERSION = 21;
+const SCHEMA_VERSION = 22;
 const MIN_SUPPORTED_SCHEMA_VERSION = 1;
 const MAX_READABLE_SCHEMA_VERSION = SCHEMA_VERSION + 1;
 const DEFAULT_MIGRATION_BUSY_TIMEOUT_MS = 3_000;
@@ -1665,6 +1665,21 @@ function ensureSchema(database: Database, stateDbPath: string): void {
             appliedAt: nowIso(),
           });
         }
+        if (existingVersion < 22) {
+          addColumnIfMissing(database, "tasks", "blocked_source", "TEXT");
+          addColumnIfMissing(database, "tasks", "blocked_reason", "TEXT");
+          addColumnIfMissing(database, "tasks", "blocked_at", "TEXT");
+          addColumnIfMissing(database, "tasks", "blocked_details", "TEXT");
+          addColumnIfMissing(database, "tasks", "blocked_checked_at", "TEXT");
+          recordStateMigrationCheckpoint(database, {
+            fromVersion: existingVersion,
+            toVersion: 22,
+            checkpoint: "v22-tasks-blocked-columns",
+            checksum: sha256Hex("state:migration:v22-tasks-blocked-columns"),
+            backupId,
+            appliedAt: nowIso(),
+          });
+        }
         recordStateMigrationCheckpoint(database, {
           fromVersion: existingVersion,
           toVersion: SCHEMA_VERSION,
@@ -1769,6 +1784,11 @@ function ensureSchema(database: Database, stateDbPath: string): void {
       heartbeat_at TEXT,
       released_at_ms INTEGER,
       released_reason TEXT,
+      blocked_source TEXT,
+      blocked_reason TEXT,
+      blocked_at TEXT,
+      blocked_details TEXT,
+      blocked_checked_at TEXT,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL,
       UNIQUE(repo_id, task_path),
@@ -3098,6 +3118,11 @@ export function recordTaskSnapshot(input: {
   heartbeatAt?: string;
   releasedAtMs?: number | null;
   releasedReason?: string | null;
+  blockedSource?: string | null;
+  blockedReason?: string | null;
+  blockedAt?: string | null;
+  blockedDetails?: string | null;
+  blockedCheckedAt?: string | null;
   at?: string;
 }): void {
   const database = requireDb();
@@ -3129,10 +3154,10 @@ export function recordTaskSnapshot(input: {
 
   database
     .query(
-      `INSERT INTO tasks(
-         repo_id, issue_number, task_path, task_name, status, session_id, session_events_path, worktree_path, worker_id, repo_slot, daemon_id, heartbeat_at, released_at_ms, released_reason, created_at, updated_at
+       `INSERT INTO tasks(
+         repo_id, issue_number, task_path, task_name, status, session_id, session_events_path, worktree_path, worker_id, repo_slot, daemon_id, heartbeat_at, released_at_ms, released_reason, blocked_source, blocked_reason, blocked_at, blocked_details, blocked_checked_at, created_at, updated_at
        ) VALUES (
-          $repo_id, $issue_number, $task_path, $task_name, $status, $session_id, $session_events_path, $worktree_path, $worker_id, $repo_slot, $daemon_id, $heartbeat_at, $released_at_ms, $released_reason, $created_at, $updated_at
+          $repo_id, $issue_number, $task_path, $task_name, $status, $session_id, $session_events_path, $worktree_path, $worker_id, $repo_slot, $daemon_id, $heartbeat_at, $released_at_ms, $released_reason, $blocked_source, $blocked_reason, $blocked_at, $blocked_details, $blocked_checked_at, $created_at, $updated_at
        )
        ON CONFLICT(repo_id, task_path) DO UPDATE SET
           issue_number = COALESCE(excluded.issue_number, tasks.issue_number),
@@ -3147,6 +3172,11 @@ export function recordTaskSnapshot(input: {
           heartbeat_at = COALESCE(excluded.heartbeat_at, tasks.heartbeat_at),
           released_at_ms = excluded.released_at_ms,
           released_reason = excluded.released_reason,
+          blocked_source = excluded.blocked_source,
+          blocked_reason = excluded.blocked_reason,
+          blocked_at = excluded.blocked_at,
+          blocked_details = excluded.blocked_details,
+          blocked_checked_at = excluded.blocked_checked_at,
           updated_at = excluded.updated_at`
     )
     .run({
@@ -3164,6 +3194,11 @@ export function recordTaskSnapshot(input: {
       $heartbeat_at: input.heartbeatAt ?? null,
       $released_at_ms: typeof input.releasedAtMs === "number" ? input.releasedAtMs : null,
       $released_reason: input.releasedReason ?? null,
+      $blocked_source: input.blockedSource ?? null,
+      $blocked_reason: input.blockedReason ?? null,
+      $blocked_at: input.blockedAt ?? null,
+      $blocked_details: input.blockedDetails ?? null,
+      $blocked_checked_at: input.blockedCheckedAt ?? null,
       $created_at: at,
       $updated_at: at,
     });
@@ -4780,6 +4815,11 @@ export type TaskOpState = {
   heartbeatAt?: string | null;
   releasedAtMs?: number | null;
   releasedReason?: string | null;
+  blockedSource?: string | null;
+  blockedReason?: string | null;
+  blockedAt?: string | null;
+  blockedDetails?: string | null;
+  blockedCheckedAt?: string | null;
 };
 
 export type OrphanedTaskOpState = TaskOpState & {
@@ -5267,7 +5307,9 @@ export function listTaskOpStatesByRepo(repo: string): TaskOpState[] {
       `SELECT t.task_path as task_path, t.issue_number as issue_number, t.status as status, t.session_id as session_id,
               t.session_events_path as session_events_path, t.worktree_path as worktree_path, t.worker_id as worker_id,
               t.repo_slot as repo_slot, t.daemon_id as daemon_id, t.heartbeat_at as heartbeat_at,
-              t.released_at_ms as released_at_ms, t.released_reason as released_reason
+              t.released_at_ms as released_at_ms, t.released_reason as released_reason,
+              t.blocked_source as blocked_source, t.blocked_reason as blocked_reason, t.blocked_at as blocked_at,
+              t.blocked_details as blocked_details, t.blocked_checked_at as blocked_checked_at
        FROM tasks t
        JOIN repos r ON r.id = t.repo_id
        WHERE r.name = $name AND t.issue_number IS NOT NULL AND t.task_path LIKE 'github:%'
@@ -5286,6 +5328,11 @@ export function listTaskOpStatesByRepo(repo: string): TaskOpState[] {
     heartbeat_at?: string | null;
     released_at_ms?: number | null;
     released_reason?: string | null;
+    blocked_source?: string | null;
+    blocked_reason?: string | null;
+    blocked_at?: string | null;
+    blocked_details?: string | null;
+    blocked_checked_at?: string | null;
   }>;
 
   return rows.map((row) => ({
@@ -5302,6 +5349,11 @@ export function listTaskOpStatesByRepo(repo: string): TaskOpState[] {
     heartbeatAt: row.heartbeat_at ?? null,
     releasedAtMs: typeof row.released_at_ms === "number" ? row.released_at_ms : null,
     releasedReason: row.released_reason ?? null,
+    blockedSource: row.blocked_source ?? null,
+    blockedReason: row.blocked_reason ?? null,
+    blockedAt: row.blocked_at ?? null,
+    blockedDetails: row.blocked_details ?? null,
+    blockedCheckedAt: row.blocked_checked_at ?? null,
   }));
 }
 
@@ -5312,7 +5364,9 @@ export function getTaskOpStateByPath(repo: string, taskPath: string): TaskOpStat
       `SELECT t.task_path as task_path, t.issue_number as issue_number, t.status as status, t.session_id as session_id,
               t.session_events_path as session_events_path, t.worktree_path as worktree_path, t.worker_id as worker_id,
               t.repo_slot as repo_slot, t.daemon_id as daemon_id, t.heartbeat_at as heartbeat_at,
-              t.released_at_ms as released_at_ms, t.released_reason as released_reason
+              t.released_at_ms as released_at_ms, t.released_reason as released_reason,
+              t.blocked_source as blocked_source, t.blocked_reason as blocked_reason, t.blocked_at as blocked_at,
+              t.blocked_details as blocked_details, t.blocked_checked_at as blocked_checked_at
        FROM tasks t
        JOIN repos r ON r.id = t.repo_id
        WHERE r.name = $name AND t.task_path = $task_path`
@@ -5331,6 +5385,11 @@ export function getTaskOpStateByPath(repo: string, taskPath: string): TaskOpStat
         heartbeat_at?: string | null;
         released_at_ms?: number | null;
         released_reason?: string | null;
+        blocked_source?: string | null;
+        blocked_reason?: string | null;
+        blocked_at?: string | null;
+        blocked_details?: string | null;
+        blocked_checked_at?: string | null;
       }
     | undefined;
 
@@ -5349,6 +5408,11 @@ export function getTaskOpStateByPath(repo: string, taskPath: string): TaskOpStat
     heartbeatAt: row.heartbeat_at ?? null,
     releasedAtMs: typeof row.released_at_ms === "number" ? row.released_at_ms : null,
     releasedReason: row.released_reason ?? null,
+    blockedSource: row.blocked_source ?? null,
+    blockedReason: row.blocked_reason ?? null,
+    blockedAt: row.blocked_at ?? null,
+    blockedDetails: row.blocked_details ?? null,
+    blockedCheckedAt: row.blocked_checked_at ?? null,
   };
 }
 

--- a/src/status-snapshot.ts
+++ b/src/status-snapshot.ts
@@ -10,13 +10,19 @@ export type StatusQueueSnapshot = {
 export type StatusQueueParityRepo = {
   repo: string;
   ghQueuedLocalBlocked: number;
+  localDepsBlockedGhInProgress: number;
+  localDepsBlockedMissingMeta: number;
   multiStatusLabels: number;
   missingStatusWithOpState: number;
   sampleGhQueuedLocalBlocked: string[];
+  sampleLocalDepsBlockedGhInProgress: string[];
+  sampleLocalDepsBlockedMissingMeta: string[];
 };
 
 export type StatusQueueParitySnapshot = {
   ghQueuedLocalBlocked: number;
+  localDepsBlockedGhInProgress: number;
+  localDepsBlockedMissingMeta: number;
   multiStatusLabels: number;
   missingStatusWithOpState: number;
   repos: StatusQueueParityRepo[];

--- a/src/worker/run-notes.ts
+++ b/src/worker/run-notes.ts
@@ -53,10 +53,8 @@ export function computeBlockedPatch(
   const detailsSource = opts.details ?? opts.reason ?? "";
   const detailsSummary = detailsSource ? summarizeBlockedDetails(detailsSource) : "";
 
-  // NOTE: GitHub-backed tasks do not currently persist blocked-* metadata in durable op-state.
-  // That means we can repeatedly rebuild AgentTask objects that have status=blocked but empty
-  // blocked-source/reason fields. Treating that as a "signature change" causes noisy re-entry
-  // notifications (blocked-deps spam) even though nothing changed.
+  // Guard against legacy rows that may still miss blocked-* metadata after migration.
+  // Without this, status-only blocked rows can cause noisy duplicate blocked notifications.
   const priorBlockedSource = typeof task["blocked-source"] === "string" ? task["blocked-source"].trim() : "";
   const priorBlockedReason = typeof task["blocked-reason"] === "string" ? task["blocked-reason"].trim() : "";
   const hasPriorBlockedSignature = Boolean(priorBlockedSource || priorBlockedReason);


### PR DESCRIPTION
## Summary
- Backport #745 implementation to `bot/integration`, including dependency-blocked status projection as queued with blocked metadata.
- Bring durable state schema support in sync with existing schema 22 data so runtime remains writable.
- Include blocked-comment + parity/reconciler updates used by the status projection.

## Testing
- `bun test src/__tests__/blocked-comment.test.ts src/__tests__/github-queue-core.test.ts src/__tests__/queue-parity-audit.test.ts src/__tests__/state-sqlite.test.ts -t "queue|blocked|schema|migration"`

Related to #745