### PR TITLE
fix(state): tolerate partially migrated schema22 task columns

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -2171,6 +2171,14 @@ function ensureSchema(database: Database, stateDbPath: string): void {
     CREATE UNIQUE INDEX IF NOT EXISTS idx_state_migration_backups_path ON state_migration_backups(backup_path);
   `);
 
+  // Backstop for mixed/partially-migrated schema 22 states where meta schema_version
+  // may already be 22 but blocked-* columns are still absent on tasks.
+  addColumnIfMissing(database, "tasks", "blocked_source", "TEXT");
+  addColumnIfMissing(database, "tasks", "blocked_reason", "TEXT");
+  addColumnIfMissing(database, "tasks", "blocked_at", "TEXT");
+  addColumnIfMissing(database, "tasks", "blocked_details", "TEXT");
+  addColumnIfMissing(database, "tasks", "blocked_checked_at", "TEXT");
+
     runMigrationsWithLock(database, () => {
       database.transaction(() => {
         const neededSchemaInvariantRepair = requiresSchemaInvariantRepair(database);


### PR DESCRIPTION
## Summary
- Add a schema backstop that unconditionally ensures `tasks.blocked_*` columns exist during DB init.
- Prevents startup/status crashes when `meta.schema_version=22` but blocked columns were not materialized.
- Keeps startup deterministic for mixed/partially-migrated durable-state databases.

## Testing
- `bun test src/__tests__/state-sqlite.test.ts -t "blocked|schema|migration|tasks"`

Related to #745