### PR TITLE
fix(merge): pause reconcile flow on GitHub rate limits

### DIFF
--- a/src/__tests__/merge-runner.test.ts
+++ b/src/__tests__/merge-runner.test.ts
@@ -78,6 +78,7 @@ function buildParams(overrides: Record<string, unknown> = {}) {
     }),
     runCiFailureTriage: async () => ({ status: "failed", run: { taskName: "x", repo: "x", outcome: "failed" } }),
     recordMergeFailureArtifact: () => {},
+    pauseIfGitHubRateLimited: async () => null,
     pauseIfHardThrottled: async () => null,
     shouldAttemptProactiveUpdate: () => ({ ok: false }),
     shouldRateLimitAutoUpdate: () => false,
@@ -196,6 +197,29 @@ describe("mergePrWithRequiredChecks 405 handling", () => {
     expect(markTaskBlockedCalls).toHaveLength(1);
     expect(markTaskBlockedCalls[0]?.source).toBe("auth");
     expect(markTaskBlockedCalls[0]?.reason).toContain("auth");
+    expect(mergeCalls).toHaveLength(0);
+  });
+
+  test("pauses instead of blocking when merge hits GitHub rate limit", async () => {
+    let pauseCalls = 0;
+    const { params, mergeCalls, markTaskBlockedCalls } = buildParams({
+      mergePullRequest: async () => {
+        throw new Error("HTTP 403: API rate limit exceeded for installation ID 123");
+      },
+      pauseIfGitHubRateLimited: async () => {
+        pauseCalls += 1;
+        return { taskName: "Issue 611", repo: "3mdistal/ralph", outcome: "throttled", sessionId: "ses_611" };
+      },
+    });
+
+    const result = await mergePrWithRequiredChecks(params);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.run.outcome).toBe("throttled");
+    }
+    expect(pauseCalls).toBe(1);
+    expect(markTaskBlockedCalls).toHaveLength(0);
     expect(mergeCalls).toHaveLength(0);
   });
 });

--- a/src/worker/repo-worker.ts
+++ b/src/worker/repo-worker.ts
@@ -5012,6 +5012,8 @@ export class RepoWorker {
       waitForRequiredChecks: async (url, checks, opts) => await this.waitForRequiredChecks(url, checks, opts),
       runCiFailureTriage: async (input) => await this.runCiFailureTriage(input as any),
       recordMergeFailureArtifact: (url, diag) => this.recordMergeFailureArtifact(url, diag),
+      pauseIfGitHubRateLimited: async (task, stage, error, sessionId) =>
+        await this.pauseIfGitHubRateLimited(task, stage, error, { sessionId }),
       pauseIfHardThrottled: async (task, stage, sid) => await this.pauseIfHardThrottled(task, stage, sid),
       shouldAttemptProactiveUpdate: (pr) => this.shouldAttemptProactiveUpdate(pr as any),
       shouldRateLimitAutoUpdate: (pr, min) => this.shouldRateLimitAutoUpdate(pr as any, min),


### PR DESCRIPTION
## Summary
- route merge reconciliation failures through GitHub rate-limit pause handling in merge lanes (base-branch read, merge call, and auto-update)
- avoid marking tasks as `blocked:runtime-error` when the real failure is transient GitHub API pressure
- add merge-runner test coverage that asserts rate-limit merge failures throttle instead of blocking

## Why
When mergeable PR reconciliation hit installation API turbulence (403/401 bursts), tasks could be left in a blocked/error state and stop progressing even though PRs remained merge-ready. This keeps those tasks resumable by moving them into throttled recovery semantics.